### PR TITLE
feat: enhance public wishlist ux

### DIFF
--- a/src/pages/lists/user-public-list.page.tsx
+++ b/src/pages/lists/user-public-list.page.tsx
@@ -1,70 +1,99 @@
-
-
+import { List } from "@refinedev/antd";
+import { useTable } from "@refinedev/antd";
+import { useUpdate } from "@refinedev/core";
 import {
-  EditButton,
-  List,
-  ShowButton,
-  useTable
-} from "@refinedev/antd";
-import { Space, Switch, Table } from "antd";
+  Button,
+  Card,
+  List as AntdList,
+  Select,
+  Tag,
+  Typography,
+} from "antd";
+import { useState } from "react";
 import { useParams } from "react-router";
 
 export type IWish = {
   id: number;
+  name: string;
+  description: string;
+  price: number;
+  priority: number;
+  is_reserved: boolean;
 };
-
-
-export type IUser = {
-  id: number;
-};
-
-
 
 export const UserPublicList: React.FC = () => {
   const params = useParams();
   const slug = params.slug;
 
+  const [sortKey, setSortKey] = useState<"price" | "priority">("priority");
+
   const { tableProps } = useTable<IWish>({
-    resource: 'wishes',
+    resource: "wishes",
     filters: {
       permanent: [
         {
-        field: "user_slugs.slug",
-        operator: "eq",
-        value: slug,
-      },
-      {
-        field: "is_public",
-        operator: "eq",
-        value: true,
-      },
-    ]
+          field: "user_slugs.slug",
+          operator: "eq",
+          value: slug,
+        },
+        {
+          field: "is_public",
+          operator: "eq",
+          value: true,
+        },
+      ],
     },
     meta: {
       select: "*, user_slugs!inner(slug)",
     },
   });
 
+  const sortedData = [...(tableProps.dataSource ?? [])].sort(
+    (a, b) => a[sortKey] - b[sortKey]
+  );
+
+  const { mutate } = useUpdate({
+    resource: "wishes",
+    mutationMode: "optimistic",
+  });
+
   return (
     <List>
-      <Table {...tableProps} rowKey="id">
-        <Table.Column key="name" dataIndex="name" title="Name" sorter />
-        <Table.Column key="description" dataIndex="description" title="Description" sorter/>
-        <Table.Column key="is_public" dataIndex="is_public" title="Is Public ?" sorter
-          render={(value: boolean) => <Switch checked={value} disabled />}
-        />
-
-        <Table.Column<IWish>
-          title="Actions"
-          dataIndex="actions"
-          render={(_, record) => (
-            <Space>
-              <EditButton hideText size="small" recordItemId={record.id} />
-              <ShowButton hideText size="small" recordItemId={record.id} />
-            </Space>
-          )}
-        />
-      </Table>
+      <Select
+        value={sortKey}
+        onChange={(value) => setSortKey(value)}
+        style={{ width: 220, marginBottom: 16 }}
+        options={[
+          { label: "Sort by Priority", value: "priority" },
+          { label: "Sort by Price", value: "price" },
+        ]}
+      />
+      <AntdList
+        dataSource={sortedData}
+        renderItem={(item) => (
+          <AntdList.Item>
+            <Card
+              title={item.name}
+              extra={<Tag color="blue">€{item.price}</Tag>}
+              style={{ width: "100%" }}
+            >
+              <Typography.Paragraph>{item.description}</Typography.Paragraph>
+              <Tag color="volcano">Priority {item.priority}</Tag>
+              <Button
+                type="primary"
+                style={{ marginTop: 12 }}
+                disabled={item.is_reserved}
+                onClick={() =>
+                  mutate({ id: item.id, values: { is_reserved: true } })
+                }
+              >
+                {item.is_reserved ? "Already reserved" : "Reserve"}
+              </Button>
+            </Card>
+          </AntdList.Item>
+        )}
+      />
     </List>
   );
 };
+


### PR DESCRIPTION
## Summary
- display wishlist items as rich cards on public list page
- allow sorting wishes by priority or price and reserving gifts

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689588de25fc832c9078077fc42adbbf