### PR TITLE
Exclude tests and stories from TypeScript build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,12 @@
     "jsx": "react-jsx"
   },
   "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.stories.ts",
+    "src/**/*.stories.tsx"
+  ],
   "references": [
     {
       "path": "./tsconfig.node.json"


### PR DESCRIPTION
## Summary
- prevent test and Storybook files from participating in TypeScript compilation by excluding them in `tsconfig.json`

## Testing
- `yarn tsc -p tsconfig.json --noEmit`
- `yarn test`
- `yarn build` *(fails: @refinedev/cli tried to access .bin)*

------
https://chatgpt.com/codex/tasks/task_e_689f2b11d3d0832c97491d0c33ff6f53