### PR TITLE
feat: add admin wish management UI

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -12,7 +12,8 @@ This document tracks high-level technical decisions and UI guidelines for the pr
 ## Components
 - **Header** uses a light peach gradient and balanced title wrapping. The counter badge is centered beneath the subtitle.
 - **Wish grid** displays a single column on small screens and switches to two columns from 400px width with generous gaps.
-- **WishCard** features a 4:3 image placeholder, subdued coral CTA, secondary link styling, and a reserved state badge.
+  - **WishCard** features a 4:3 image placeholder, subdued coral CTA, secondary link styling, and a reserved state badge.
+  - See `admin-wishes-ui.md` for details on the administration CRUD interface.
 
 ## Accessibility
 - Interactive elements maintain a minimum touch area of 44px and include aria attributes for state changes.

--- a/documentation/admin-wishes-ui.md
+++ b/documentation/admin-wishes-ui.md
@@ -1,0 +1,12 @@
+# Admin Wishes UI
+
+This module provides a modern CRUD experience for managing wishes using React, Refine and Ant Design. It currently includes:
+
+- **WishesListPage**: table view with inline editing for price, status and public visibility.
+- **WishDrawer** with **WishForm**: drawer-based form divided in tabs (only General tab implemented) to create or edit a wish. Metadata from pasted URLs is mocked.
+- **QuickAddBar**: sticky input allowing quick creation from a URL. It opens the drawer pre‑filled.
+- **PreviewPublic**: renders a public-facing `WishCard` preview of a wish.
+- **useWishMetadata hook**: fetches mock metadata for a URL.
+- **smartDataProvider**: hybrid data provider merging Supabase records with localStorage for missing fields.
+
+All optional fields are stored in localStorage when not available in Supabase, enabling schema-less iteration.

--- a/documentation/admin-wishes-ui.md
+++ b/documentation/admin-wishes-ui.md
@@ -6,7 +6,7 @@ This module provides a modern CRUD experience for managing wishes using React, R
 - **WishDrawer** with **WishForm**: drawer-based form divided in tabs (only General tab implemented) to create or edit a wish. Metadata from pasted URLs is mocked.
 - **QuickAddBar**: sticky input allowing quick creation from a URL. It opens the drawer pre‑filled.
 - **PreviewPublic**: renders a public-facing `WishCard` preview of a wish.
-- **useWishMetadata hook**: fetches mock metadata for a URL.
-- **smartDataProvider**: hybrid data provider merging Supabase records with localStorage for missing fields.
+ - **useWishMetadata hook**: fetches mock metadata for a URL.
+ - **smartDataProvider**: hybrid data provider merging Supabase records with localStorage for missing fields, conforming to Refine's standard `DataProvider` interface.
 
 All optional fields are stored in localStorage when not available in Supabase, enabling schema-less iteration.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,17 +12,18 @@ import routerBindings, {
   DocumentTitleHandler,
   UnsavedChangesNotifier,
 } from "@refinedev/react-router";
-import { dataProvider, liveProvider } from "@refinedev/supabase";
+  import { liveProvider } from "@refinedev/supabase";
 import { BrowserRouter, Route, Routes } from "react-router";
 import { ConfigProvider } from "antd";
 import authProvider from "./authProvider";
 import { AnonymousLogin } from "./components/auth/anonymous-login";
 import { ColorModeContextProvider } from "./contexts/color-mode";
 import { PublicWishlistPage } from "./pages/wishes/public-wishlist.page";
-import { NewWishPage } from "./pages/wishes/new-wish.page";
-import { EditWishListPage } from "./pages/wishes/wish-list-edit.page";
-import { theme } from "./theme";
-import { supabaseClient } from "./utility";
+  import { NewWishPage } from "./pages/wishes/new-wish.page";
+  import { theme } from "./theme";
+  import { supabaseClient } from "./utility";
+  import { smartDataProvider } from "./providers/smartDataProvider";
+  import { WishesListPage } from "./pages/wishes/WishesListPage";
 
 function App() {
   return (
@@ -35,8 +36,8 @@ function App() {
           <GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />
           <RefineSnackbarProvider>
               <Refine
-                dataProvider={dataProvider(supabaseClient)}
-                liveProvider={liveProvider(supabaseClient)}
+                  dataProvider={smartDataProvider}
+                  liveProvider={liveProvider(supabaseClient)}
                 authProvider={authProvider}
                 routerProvider={routerBindings}
                 notificationProvider={useNotificationProvider}
@@ -56,7 +57,7 @@ function App() {
               >
                     <Authenticated key="protected" fallback={<AnonymousLogin/>}>
                       <Routes>
-                          <Route path="/wishes" element={<EditWishListPage />} />
+                            <Route path="/wishes" element={<WishesListPage />} />
                           <Route path="/new-wish" element={<NewWishPage />} />
                           {/* <Route path="/:slug/:id" element={<WishShow />} /> */}
                           {/* <Route path="/wishes/:id/edit" element={<WishEdit />} /> */}

--- a/src/components/admin/wishes/PreviewPublic.tsx
+++ b/src/components/admin/wishes/PreviewPublic.tsx
@@ -3,7 +3,7 @@ import { WishUI } from "../../../types/wish";
 
 export const PreviewPublic: React.FC<{ wish: WishUI }> = ({ wish }) => {
   const mapped = {
-    id: wish.id,
+    id: Number(wish.id),
     name: wish.title,
     image: wish.imageUrl,
     meta: wish.url,

--- a/src/components/admin/wishes/PreviewPublic.tsx
+++ b/src/components/admin/wishes/PreviewPublic.tsx
@@ -1,0 +1,18 @@
+import { WishCard } from "../../wish/WishCard";
+import { WishUI } from "../../../types/wish";
+
+export const PreviewPublic: React.FC<{ wish: WishUI }> = ({ wish }) => {
+  const mapped = {
+    id: wish.id,
+    name: wish.title,
+    image: wish.imageUrl,
+    meta: wish.url,
+    isReserved: wish.status === "reserved",
+  };
+
+  return (
+    <div style={{ padding: 16 }}>
+      <WishCard wish={mapped} />
+    </div>
+  );
+};

--- a/src/components/admin/wishes/QuickAddBar.tsx
+++ b/src/components/admin/wishes/QuickAddBar.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { Input, Button, Space } from "antd";
+
+export type QuickAddBarProps = {
+  onAdd: (url?: string) => void;
+};
+
+export const QuickAddBar: React.FC<QuickAddBarProps> = ({ onAdd }) => {
+  const [link, setLink] = useState("");
+
+  const handleSubmit = () => {
+    onAdd(link);
+    setLink("");
+  };
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        bottom: 24,
+        right: 24,
+        background: "#fff",
+        padding: 12,
+        borderRadius: 12,
+        boxShadow: "0 2px 8px rgba(0,0,0,0.15)",
+      }}
+    >
+      <Space>
+        <Input
+          placeholder="Colle un lien ou ajoute un souhait"
+          value={link}
+          onChange={(e) => setLink(e.target.value)}
+          size="large"
+          style={{ width: 260 }}
+        />
+        <Button type="primary" size="large" onClick={handleSubmit}>
+          + Ajouter
+        </Button>
+      </Space>
+    </div>
+  );
+};

--- a/src/components/admin/wishes/WishDrawer.tsx
+++ b/src/components/admin/wishes/WishDrawer.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import { Drawer, Tabs, Button, Space, Form } from "antd";
+import { WishUI } from "../../../types/wish";
+import { WishForm } from "./WishForm";
+
+export type WishDrawerProps = {
+  open: boolean;
+  initialValues?: Partial<WishUI>;
+  onClose: () => void;
+  onSave: (values: WishUI) => void;
+};
+
+export const WishDrawer: React.FC<WishDrawerProps> = ({ open, initialValues, onClose, onSave }) => {
+  const [saving, setSaving] = useState(false);
+  const [form] = Form.useForm();
+
+  const handleSubmit = async (values: WishUI) => {
+    setSaving(true);
+    await onSave(values);
+    setSaving(false);
+  };
+
+  return (
+    <Drawer
+      width={520}
+      open={open}
+      destroyOnClose
+      title="Éditer le souhait"
+      onClose={onClose}
+      extra={
+        <Space>
+          <Button onClick={onClose}>Annuler</Button>
+          <Button type="primary" loading={saving} onClick={() => form.submit()}>
+            Enregistrer
+          </Button>
+        </Space>
+      }
+    >
+      <Tabs
+        items={[
+          {
+            key: "general",
+            label: "Général",
+            children: (
+              <WishForm
+                form={form}
+                initialValues={initialValues}
+                onSubmit={handleSubmit}
+              />
+            ),
+          },
+        ]}
+      />
+    </Drawer>
+  );
+};

--- a/src/components/admin/wishes/WishForm.tsx
+++ b/src/components/admin/wishes/WishForm.tsx
@@ -1,0 +1,149 @@
+import { useEffect } from "react";
+import { useForm, Controller } from "react-hook-form";
+import { Input, InputNumber, Select, Switch, Segmented, Form, Typography } from "antd";
+import type { FormInstance } from "antd";
+import { WishUI } from "../../../types/wish";
+import { useWishMetadata } from "../../../hooks/useWishMetadata";
+
+const { TextArea } = Input;
+
+export type WishFormProps = {
+  initialValues?: Partial<WishUI>;
+  onSubmit: (values: WishUI) => void;
+  form: FormInstance;
+};
+
+export const WishForm: React.FC<WishFormProps> = ({ initialValues, onSubmit, form }) => {
+  const { control, handleSubmit, watch, setValue } = useForm<WishUI>({
+    defaultValues: { quantity: 1, priority: 2, ...initialValues },
+  });
+
+  const url = watch("url");
+  const { metadata } = useWishMetadata(url);
+
+  useEffect(() => {
+    if (metadata?.title && !watch("title")) {
+      setValue("title", metadata.title);
+    }
+    if (metadata?.image && !watch("imageUrl")) {
+      setValue("imageUrl", metadata.image);
+    }
+  }, [metadata, watch, setValue]);
+
+  return (
+    <Form layout="vertical" form={form} onFinish={handleSubmit(onSubmit)}>
+      <Controller
+        name="title"
+        control={control}
+        rules={{ required: true }}
+        render={({ field }) => (
+          <Form.Item label="Titre" required>
+            <Input size="large" {...field} />
+          </Form.Item>
+        )}
+      />
+      <Controller
+        name="url"
+        control={control}
+        render={({ field }) => (
+          <Form.Item label="URL">
+            <Input size="large" {...field} />
+          </Form.Item>
+        )}
+      />
+      {metadata && (
+        <Typography.Text type="secondary">{metadata.siteName}</Typography.Text>
+      )}
+      <Controller
+        name="imageUrl"
+        control={control}
+        render={({ field }) => (
+          <Form.Item label="Image URL">
+            <Input size="large" {...field} />
+          </Form.Item>
+        )}
+      />
+      <Controller
+        name="price"
+        control={control}
+        render={({ field }) => (
+          <Form.Item label="Prix">
+            <InputNumber min={0} style={{ width: "100%" }} {...field} />
+          </Form.Item>
+        )}
+      />
+      <Controller
+        name="currency"
+        control={control}
+        render={({ field }) => (
+          <Form.Item label="Devise">
+            <Select {...field} options={["EUR", "USD", "GBP"].map(v => ({ value: v }))} />
+          </Form.Item>
+        )}
+      />
+      <Controller
+        name="description"
+        control={control}
+        render={({ field }) => (
+          <Form.Item label="Description">
+            <TextArea rows={3} {...field} />
+          </Form.Item>
+        )}
+      />
+      <Controller
+        name="quantity"
+        control={control}
+        render={({ field }) => (
+          <Form.Item label="Quantité">
+            <InputNumber min={1} style={{ width: "100%" }} {...field} />
+          </Form.Item>
+        )}
+      />
+      <Controller
+        name="priority"
+        control={control}
+        render={({ field }) => (
+          <Form.Item label="Priorité">
+            <Segmented {...field} options={[1, 2, 3]} />
+          </Form.Item>
+        )}
+      />
+      <Controller
+        name="tags"
+        control={control}
+        render={({ field }) => (
+          <Form.Item label="Tags">
+            <Select mode="tags" tokenSeparators={[","]} {...field} />
+          </Form.Item>
+        )}
+      />
+      <Controller
+        name="notePrivate"
+        control={control}
+        render={({ field }) => (
+          <Form.Item label="Note privée">
+            <TextArea rows={3} {...field} />
+          </Form.Item>
+        )}
+      />
+      <Controller
+        name="status"
+        control={control}
+        render={({ field }) => (
+          <Form.Item label="Statut">
+            <Select {...field} options={["draft", "available", "reserved", "received", "archived"].map(v => ({ value: v }))} />
+          </Form.Item>
+        )}
+      />
+      <Controller
+        name="isPublic"
+        control={control}
+        render={({ field }) => (
+          <Form.Item label="Public ?" valuePropName="checked">
+            <Switch {...field} />
+          </Form.Item>
+        )}
+      />
+    </Form>
+  );
+};

--- a/src/hooks/useWishMetadata.ts
+++ b/src/hooks/useWishMetadata.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+
+export type Metadata = {
+  siteName?: string;
+  title?: string;
+  favicon?: string;
+  image?: string;
+};
+
+export const useWishMetadata = (url?: string) => {
+  const [metadata, setMetadata] = useState<Metadata | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!url) return;
+    setLoading(true);
+    const timer = setTimeout(() => {
+      // Mocked metadata fetch
+      setMetadata({
+        siteName: "Amazon",
+        title: "Titre détecté",
+        favicon: "https://www.amazon.com/favicon.ico",
+        image: `https://picsum.photos/seed/${encodeURIComponent(url)}/640/480`,
+      });
+      setLoading(false);
+    }, 800);
+    return () => clearTimeout(timer);
+  }, [url]);
+
+  return { metadata, loading };
+};

--- a/src/pages/wishes/WishesListPage.tsx
+++ b/src/pages/wishes/WishesListPage.tsx
@@ -1,0 +1,107 @@
+import { useState } from "react";
+import {
+  List,
+  useTable,
+} from "@refinedev/antd";
+import { Table, Image, Switch, Select, InputNumber, Tag, Button } from "antd";
+import { useCreate, useUpdate } from "@refinedev/core";
+import { WishDrawer } from "../../components/admin/wishes/WishDrawer";
+import { QuickAddBar } from "../../components/admin/wishes/QuickAddBar";
+import { WishUI } from "../../types/wish";
+
+export const WishesListPage: React.FC = () => {
+  const { tableProps } = useTable<WishUI>({ resource: "wishes" });
+  const { mutate: update } = useUpdate();
+  const { mutate: create } = useCreate();
+
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [editing, setEditing] = useState<Partial<WishUI> | undefined>();
+
+  const handleSave = (values: WishUI) => {
+    if (editing?.id) {
+      update({ resource: "wishes", id: editing.id, values }, {
+        onSuccess: () => setDrawerOpen(false),
+      });
+    } else {
+      create({ resource: "wishes", values }, {
+        onSuccess: () => setDrawerOpen(false),
+      });
+    }
+  };
+
+  const openDrawer = (initial?: Partial<WishUI>) => {
+    setEditing(initial);
+    setDrawerOpen(true);
+  };
+
+  return (
+    <List
+      headerButtons={({ defaultButtons }) => (
+        <>
+          {defaultButtons}
+          <Button type="primary" onClick={() => openDrawer()}>Créer un souhait</Button>
+        </>
+      )}
+    >
+      <Table {...tableProps} rowKey="id" scroll={{ x: true }}>
+        <Table.Column<WishUI>
+          title="Image"
+          dataIndex="imageUrl"
+          render={(value) => value ? <Image src={value} width={48} /> : null}
+        />
+        <Table.Column<WishUI> title="Titre" dataIndex="title" />
+        <Table.Column<WishUI>
+          title="Prix"
+          dataIndex="price"
+          render={(value, record) => (
+            <InputNumber
+              min={0}
+              defaultValue={value}
+              onBlur={(e) => update({ resource: "wishes", id: record.id, values: { price: Number(e.target.value) } })}
+            />
+          )}
+        />
+        <Table.Column<WishUI>
+          title="Statut"
+          dataIndex="status"
+          render={(value, record) => (
+            <Select
+              defaultValue={value}
+              onChange={(val) => update({ resource: "wishes", id: record.id, values: { status: val } })}
+              options={["draft", "available", "reserved", "received", "archived"].map(v => ({ value: v }))}
+            />
+          )}
+        />
+        <Table.Column<WishUI>
+          title="Public ?"
+          dataIndex="isPublic"
+          render={(value, record) => (
+            <Switch
+              checked={value}
+              onChange={(val) => update({ resource: "wishes", id: record.id, values: { isPublic: val } })}
+            />
+          )}
+        />
+        <Table.Column<WishUI>
+          title="Tags"
+          dataIndex="tags"
+          render={(tags: string[] = []) => tags.map((t) => <Tag key={t}>{t}</Tag>)}
+        />
+        <Table.Column<WishUI>
+          title="Actions"
+          dataIndex="actions"
+          render={(_, record) => (
+            <Button onClick={() => openDrawer(record)}>Éditer</Button>
+          )}
+        />
+      </Table>
+      <WishDrawer
+        open={drawerOpen}
+        initialValues={editing}
+        onClose={() => setDrawerOpen(false)}
+        onSave={handleSave}
+      />
+      <QuickAddBar onAdd={(url) => openDrawer({ url })} />
+    </List>
+  );
+};

--- a/src/providers/smartDataProvider.ts
+++ b/src/providers/smartDataProvider.ts
@@ -18,48 +18,52 @@ function writeExtras(store: WishExtraStore) {
   localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(store));
 }
 
-export const smartDataProvider: DataProvider = {
+export const smartDataProvider = {
   ...baseProvider,
-  async getList(resource, params) {
-    const supRes = await baseProvider.getList(resource, params);
-    if (resource !== "wishes") return supRes;
+  async getList(params: any) {
+    const supRes = await baseProvider.getList(params);
+    if (params.resource !== "wishes") return supRes;
     const extras = readExtras();
     return {
       ...supRes,
-      data: supRes.data.map((item: any) => ({ ...item, ...extras[item.id] })),
+      data: supRes.data.map((item: any) => ({
+        ...item,
+        ...extras[String(item.id)],
+      })),
     };
   },
-  async getOne(resource, params) {
-    const supRes = await baseProvider.getOne(resource, params);
-    if (resource !== "wishes") return supRes;
+  async getOne(params: any) {
+    const supRes = await baseProvider.getOne(params);
+    if (params.resource !== "wishes") return supRes;
     const extras = readExtras();
+    const idKey = String(supRes.data.id);
     return {
       ...supRes,
-      data: { ...supRes.data, ...extras[supRes.data.id] },
+      data: { ...supRes.data, ...extras[idKey] },
     };
   },
-  async create(resource, params) {
-    if (resource !== "wishes") return baseProvider.create(resource, params);
-    const { variables } = params;
-    const supRes = await baseProvider.create(resource, { variables });
+  async create(params: any) {
+    if (params.resource !== "wishes") return baseProvider.create(params);
+    const supRes = await baseProvider.create(params);
     const extras = readExtras();
-    extras[supRes.data.id] = { ...extras[supRes.data.id], ...variables };
+    const idKey = String(supRes.data.id);
+    extras[idKey] = { ...extras[idKey], ...params.variables };
     writeExtras(extras);
     return {
       ...supRes,
-      data: { ...supRes.data, ...extras[supRes.data.id] },
+      data: { ...supRes.data, ...extras[idKey] },
     };
   },
-  async update(resource, params) {
-    if (resource !== "wishes") return baseProvider.update(resource, params);
-    const { variables, id } = params;
-    const supRes = await baseProvider.update(resource, { id, variables });
+  async update(params: any) {
+    if (params.resource !== "wishes") return baseProvider.update(params);
+    const supRes = await baseProvider.update(params);
     const extras = readExtras();
-    extras[id as string] = { ...extras[id as string], ...variables };
+    const idKey = String(params.id);
+    extras[idKey] = { ...extras[idKey], ...params.variables };
     writeExtras(extras);
     return {
       ...supRes,
-      data: { ...supRes.data, ...extras[id as string] },
+      data: { ...supRes.data, ...extras[idKey] },
     };
   },
-};
+} as DataProvider;

--- a/src/providers/smartDataProvider.ts
+++ b/src/providers/smartDataProvider.ts
@@ -1,0 +1,65 @@
+import { dataProvider as supabaseDataProvider } from "@refinedev/supabase";
+import type { DataProvider } from "@refinedev/core";
+import { WishExtraStore } from "../types/wish";
+import { supabaseClient } from "../utility";
+
+const baseProvider = supabaseDataProvider(supabaseClient);
+const LOCAL_STORAGE_KEY = "wishes_extra";
+
+function readExtras(): WishExtraStore {
+  try {
+    return JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) || "{}") as WishExtraStore;
+  } catch {
+    return {};
+  }
+}
+
+function writeExtras(store: WishExtraStore) {
+  localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(store));
+}
+
+export const smartDataProvider: DataProvider = {
+  ...baseProvider,
+  async getList(resource, params) {
+    const supRes = await baseProvider.getList(resource, params);
+    if (resource !== "wishes") return supRes;
+    const extras = readExtras();
+    return {
+      ...supRes,
+      data: supRes.data.map((item: any) => ({ ...item, ...extras[item.id] })),
+    };
+  },
+  async getOne(resource, params) {
+    const supRes = await baseProvider.getOne(resource, params);
+    if (resource !== "wishes") return supRes;
+    const extras = readExtras();
+    return {
+      ...supRes,
+      data: { ...supRes.data, ...extras[supRes.data.id] },
+    };
+  },
+  async create(resource, params) {
+    if (resource !== "wishes") return baseProvider.create(resource, params);
+    const { variables } = params;
+    const supRes = await baseProvider.create(resource, { variables });
+    const extras = readExtras();
+    extras[supRes.data.id] = { ...extras[supRes.data.id], ...variables };
+    writeExtras(extras);
+    return {
+      ...supRes,
+      data: { ...supRes.data, ...extras[supRes.data.id] },
+    };
+  },
+  async update(resource, params) {
+    if (resource !== "wishes") return baseProvider.update(resource, params);
+    const { variables, id } = params;
+    const supRes = await baseProvider.update(resource, { id, variables });
+    const extras = readExtras();
+    extras[id as string] = { ...extras[id as string], ...variables };
+    writeExtras(extras);
+    return {
+      ...supRes,
+      data: { ...supRes.data, ...extras[id as string] },
+    };
+  },
+};

--- a/src/types/wish.ts
+++ b/src/types/wish.ts
@@ -1,0 +1,26 @@
+export type WishStatus = "draft" | "available" | "reserved" | "received" | "archived";
+
+export type WishUI = {
+  id: string;
+  title: string;
+  description?: string;
+  url?: string;
+  price?: number;
+  currency?: "EUR" | "USD" | "GBP";
+  imageUrl?: string;
+  quantity?: number;
+  priority?: 1 | 2 | 3;
+  isPublic?: boolean;
+  status?: WishStatus;
+  notePrivate?: string;
+  tags?: string[];
+  metadata?: {
+    siteName?: string;
+    favicon?: string;
+    title?: string;
+  };
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type WishExtraStore = Record<string, Partial<WishUI>>;


### PR DESCRIPTION
## Summary
- scaffold WishUI types and hybrid smartDataProvider using Supabase plus localStorage
- add drawer-based wish form with metadata fetch and quick-add link bar
- expose admin wishes list with inline editing

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a0978396e0832c893a74493d1c9c79