### PR TITLE
refactor: use Supabase generated types

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -18,6 +18,9 @@ This document tracks high-level technical decisions and UI guidelines for the pr
 ## Accessibility
 - Interactive elements maintain a minimum touch area of 44px and include aria attributes for state changes.
 
+## Database
+Supabase Postgres powers persistence. Types are generated with `npx supabase gen types typescript --project-id $SUPABASE_PROJECT_ID --schema public > database.types.ts` and imported across the codebase to ensure queries match the schema.
+
 ## Build
 - The project builds via `tsc && vite build` to ensure compatibility with Yarn PnP.
 - Extra runtime helpers rely on `@mui/system` for MUI Data Grid and `tslib` for TypeScript transpiled helpers.

--- a/src/authProvider.ts
+++ b/src/authProvider.ts
@@ -1,6 +1,7 @@
 import { AuthProvider } from "@refinedev/core";
 import { customAlphabet } from "nanoid";
 import { supabaseClient } from "./utility";
+import type { TablesInsert } from "../database.types";
 
 const nanoid = customAlphabet('1234567890abcdef', 5)
 
@@ -23,10 +24,12 @@ const authProvider: AuthProvider = {
     }
 
     if (data.user?.id) {
-      await supabaseClient.from('user_slugs').insert({
-        id: data.user.id,
-        slug: nanoid()
-      })
+      await supabaseClient
+        .from("user_slugs")
+        .insert<TablesInsert<"user_slugs">>({
+          id: data.user.id,
+          slug: nanoid(),
+        });
     }
 
     return {

--- a/src/components/admin/wishes/CreateWishWizard.tsx
+++ b/src/components/admin/wishes/CreateWishWizard.tsx
@@ -40,7 +40,7 @@ export const CreateWishWizard: React.FC<CreateWishWizardProps> = ({
   const [loading, setLoading] = useState(false);
   const [form] = Form.useForm<WishUI>();
   const url = Form.useWatch("url", form);
-  const { metadata } = useLinkMetadata(url);
+  const { metadata } = useLinkMetadata(url ?? undefined);
   const screens = Grid.useBreakpoint();
   const isMobile = !screens.md;
 
@@ -64,8 +64,8 @@ export const CreateWishWizard: React.FC<CreateWishWizardProps> = ({
     if (metadata) {
       const existing = form.getFieldsValue();
       form.setFieldsValue({
-        title: existing.title || metadata.title,
-        imageUrl: existing.imageUrl || metadata.image,
+        name: existing.name || metadata.title,
+        image_url: existing.image_url || metadata.image,
       } as any);
     }
   }, [metadata, form]);
@@ -73,7 +73,7 @@ export const CreateWishWizard: React.FC<CreateWishWizardProps> = ({
   const validateStep = () => {
     if (current === 1) {
       form
-        .validateFields(["title", "price", "url"])
+        .validateFields(["name", "price", "url"])
         .then(() => setStepValid(true))
         .catch(() => setStepValid(false));
     } else {
@@ -193,7 +193,7 @@ export const CreateWishWizard: React.FC<CreateWishWizardProps> = ({
             {metadata.favicon && (
               <img src={metadata.favicon} alt="" width={16} height={16} />
             )}
-            <span>{metadata.title || metadata.siteName}</span>
+            <span>{metadata.title || metadata.site_name}</span>
           </Space>
         </div>
       )}
@@ -208,13 +208,13 @@ export const CreateWishWizard: React.FC<CreateWishWizardProps> = ({
             Ajoute ce qui compte : une jolie photo, un petit mot…
           </Typography.Paragraph>
           <Form.Item
-            name="title"
+            name="name"
             label="Titre"
             rules={[{ required: true, message: "Titre requis" }]}
           >
             <Input size="large" onBlur={validateStep} />
           </Form.Item>
-          <Form.Item name="imageUrl" label="Image">
+          <Form.Item name="image_url" label="Image">
             <Input size="large" onBlur={validateStep} />
           </Form.Item>
           <Form.Item
@@ -255,7 +255,7 @@ export const CreateWishWizard: React.FC<CreateWishWizardProps> = ({
               onChange={validateStep}
             />
           </Form.Item>
-          <Form.Item name="notePrivate" label="Note privée">
+          <Form.Item name="note_private" label="Note privée">
             <Input.TextArea rows={2} onBlur={validateStep} />
           </Form.Item>
         </Card>
@@ -277,7 +277,7 @@ export const CreateWishWizard: React.FC<CreateWishWizardProps> = ({
           onChange={validateStep}
         />
       </Form.Item>
-      <Form.Item name="isPublic" label="Public ?" valuePropName="checked">
+      <Form.Item name="is_public" label="Public ?" valuePropName="checked">
         <Switch onChange={validateStep} />
       </Form.Item>
     </Card>

--- a/src/components/admin/wishes/EditWishDrawer.tsx
+++ b/src/components/admin/wishes/EditWishDrawer.tsx
@@ -92,13 +92,13 @@ export const EditWishDrawer: React.FC<EditWishDrawerProps> = ({
             label: "Général",
             children: (
               <Form layout="vertical" form={form}>
-                <Form.Item name="title" label="Titre" rules={[{ required: true }]}> 
+                <Form.Item name="name" label="Titre" rules={[{ required: true }]}> 
                   <Input size="large" />
                 </Form.Item>
-                <Form.Item name="url" label="URL">
+                <Form.Item name="url" label="URL"> 
                   <Input size="large" />
                 </Form.Item>
-                <Form.Item name="imageUrl" label="Image">
+                <Form.Item name="image_url" label="Image"> 
                   <Input size="large" />
                 </Form.Item>
               </Form>
@@ -124,7 +124,7 @@ export const EditWishDrawer: React.FC<EditWishDrawerProps> = ({
                 <Form.Item name="tags" label="Tags">
                   <Select mode="tags" tokenSeparators={[","]} />
                 </Form.Item>
-                <Form.Item name="notePrivate" label="Note privée">
+                <Form.Item name="note_private" label="Note privée"> 
                   <Input.TextArea rows={3} />
                 </Form.Item>
                 <Form.Item name="priority" label="Priorité">
@@ -141,7 +141,7 @@ export const EditWishDrawer: React.FC<EditWishDrawerProps> = ({
                 <Form.Item name="status" label="Statut">
                   <Select options={["draft", "available", "reserved", "received", "archived"].map((v) => ({ value: v }))} />
                 </Form.Item>
-                <Form.Item name="isPublic" label="Public ?" valuePropName="checked">
+                <Form.Item name="is_public" label="Public ?" valuePropName="checked">
                   <Switch />
                 </Form.Item>
               </Form>

--- a/src/components/admin/wishes/PreviewPublic.tsx
+++ b/src/components/admin/wishes/PreviewPublic.tsx
@@ -1,14 +1,16 @@
 import { WishCard } from "../../wish/WishCard";
+import type { Wish } from "../../wish/types";
 import { WishUI } from "../../../types/wish";
 
 export const PreviewPublic: React.FC<{ wish: WishUI }> = ({ wish }) => {
   const mapped = {
+    ...wish,
     id: Number(wish.id),
-    name: wish.title,
-    image: wish.imageUrl,
-    meta: wish.url,
+    name: wish.name,
+    image: wish.image_url,
+    meta: wish.url ?? undefined,
     isReserved: wish.status === "reserved",
-  };
+  } as Wish;
 
   return (
     <div style={{ padding: 16 }}>

--- a/src/components/admin/wishes/WishForm.tsx
+++ b/src/components/admin/wishes/WishForm.tsx
@@ -19,26 +19,26 @@ export const WishForm: React.FC<WishFormProps> = ({ initialValues, onSubmit, for
   });
 
   const url = watch("url");
-  const { metadata } = useWishMetadata(url);
+  const { metadata } = useWishMetadata(url ?? undefined);
 
   useEffect(() => {
-    if (metadata?.title && !watch("title")) {
-      setValue("title", metadata.title);
+    if (metadata?.title && !watch("name")) {
+      setValue("name", metadata.title);
     }
-    if (metadata?.image && !watch("imageUrl")) {
-      setValue("imageUrl", metadata.image);
+    if (metadata?.image && !watch("image_url")) {
+      setValue("image_url", metadata.image);
     }
   }, [metadata, watch, setValue]);
 
   return (
     <Form layout="vertical" form={form} onFinish={handleSubmit(onSubmit)}>
       <Controller
-        name="title"
+        name="name"
         control={control}
         rules={{ required: true }}
         render={({ field }) => (
           <Form.Item label="Titre" required>
-            <Input size="large" {...field} />
+              <Input size="large" {...field} value={field.value ?? ""} />
           </Form.Item>
         )}
       />
@@ -47,19 +47,19 @@ export const WishForm: React.FC<WishFormProps> = ({ initialValues, onSubmit, for
         control={control}
         render={({ field }) => (
           <Form.Item label="URL">
-            <Input size="large" {...field} />
+              <Input size="large" {...field} value={field.value ?? ""} />
           </Form.Item>
         )}
       />
       {metadata && (
-        <Typography.Text type="secondary">{metadata.siteName}</Typography.Text>
+        <Typography.Text type="secondary">{metadata.site_name}</Typography.Text>
       )}
       <Controller
-        name="imageUrl"
+        name="image_url"
         control={control}
         render={({ field }) => (
           <Form.Item label="Image URL">
-            <Input size="large" {...field} />
+              <Input size="large" {...field} value={field.value ?? ""} />
           </Form.Item>
         )}
       />
@@ -86,7 +86,7 @@ export const WishForm: React.FC<WishFormProps> = ({ initialValues, onSubmit, for
         control={control}
         render={({ field }) => (
           <Form.Item label="Description">
-            <TextArea rows={3} {...field} />
+              <TextArea rows={3} {...field} value={field.value ?? ""} />
           </Form.Item>
         )}
       />
@@ -118,7 +118,7 @@ export const WishForm: React.FC<WishFormProps> = ({ initialValues, onSubmit, for
         )}
       />
       <Controller
-        name="notePrivate"
+        name="note_private"
         control={control}
         render={({ field }) => (
           <Form.Item label="Note privée">
@@ -136,7 +136,7 @@ export const WishForm: React.FC<WishFormProps> = ({ initialValues, onSubmit, for
         )}
       />
       <Controller
-        name="isPublic"
+        name="is_public"
         control={control}
         render={({ field }) => (
           <Form.Item label="Public ?" valuePropName="checked">

--- a/src/components/wish/types.ts
+++ b/src/components/wish/types.ts
@@ -1,7 +1,7 @@
-export interface Wish {
-  id: number;
-  name: string;
+import type { Tables } from "../../../database.types";
+
+export type Wish = Tables<"wishes"> & {
   image?: string;
   meta?: string;
   isReserved?: boolean;
-}
+};

--- a/src/hooks/useLinkMetadata.ts
+++ b/src/hooks/useLinkMetadata.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 
 export type LinkMetadata = {
-  siteName?: string;
+  site_name?: string;
   title?: string;
   favicon?: string;
   image?: string;

--- a/src/hooks/useWishMetadata.ts
+++ b/src/hooks/useWishMetadata.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 
 export type Metadata = {
-  siteName?: string;
+  site_name?: string;
   title?: string;
   favicon?: string;
   image?: string;
@@ -17,7 +17,7 @@ export const useWishMetadata = (url?: string) => {
     const timer = setTimeout(() => {
       // Mocked metadata fetch
       setMetadata({
-        siteName: "Amazon",
+        site_name: "Amazon",
         title: "Titre détecté",
         favicon: "https://www.amazon.com/favicon.ico",
         image: `https://picsum.photos/seed/${encodeURIComponent(url)}/640/480`,

--- a/src/pages/lists/user-public-list.page.tsx
+++ b/src/pages/lists/user-public-list.page.tsx
@@ -8,10 +8,9 @@ import {
 } from "@refinedev/antd";
 import { Space, Switch, Table } from "antd";
 import { useParams } from "react-router";
+import type { Tables } from "../../../database.types";
 
-export type IWish = {
-  id: number;
-};
+export type IWish = Tables<"wishes">;
 
 
 export type IUser = {

--- a/src/pages/wishes/WishesListPage.tsx
+++ b/src/pages/wishes/WishesListPage.tsx
@@ -36,19 +36,19 @@ export const WishesListPage: React.FC = () => {
   };
 
   const openEdit = (record: WishUI) => {
-    const extras = getExtras(record.id);
+    const extras = getExtras(String(record.id));
     setEditing(mapDbToWishUI(record, extras));
     setEditOpen(true);
   };
 
   const handleEditSave = async (values: WishUI) => {
     if (!editing) return;
-    const { notePrivate, tags, metadata, ...dbValues } = values;
+    const { note_private, tags, metadata, ...dbValues } = values;
     update(
       { resource: "wishes", id: editing.id, values: dbValues },
       {
         onSuccess: () => {
-          setExtras(editing.id, { notePrivate, tags, metadata });
+          setExtras(String(editing.id), { note_private, tags, metadata });
           message.success("Enregistré ✨");
           setEditOpen(false);
         },
@@ -58,13 +58,13 @@ export const WishesListPage: React.FC = () => {
   };
 
   const handleCreate = (values: WishUI) => {
-    const { notePrivate, tags, metadata, ...dbValues } = values;
+    const { note_private, tags, metadata, ...dbValues } = values;
     create(
       { resource: "wishes", values: dbValues },
       {
         onSuccess: (data) => {
           if (data?.data?.id) {
-            setExtras(String(data.data.id), { notePrivate, tags, metadata });
+            setExtras(String(data.data.id), { note_private, tags, metadata });
           }
           message.success("Enregistré ✨");
           setCreateOpen(false);
@@ -89,10 +89,10 @@ export const WishesListPage: React.FC = () => {
       <Table {...tableProps} rowKey="id" scroll={{ x: true }}>
         <Table.Column<WishUI>
           title="Image"
-          dataIndex="imageUrl"
+          dataIndex="image_url"
           render={(value) => value ? <Image src={value} width={48} /> : null}
         />
-        <Table.Column<WishUI> title="Titre" dataIndex="title" />
+        <Table.Column<WishUI> title="Titre" dataIndex="name" />
         <Table.Column<WishUI>
           title="Prix"
           dataIndex="price"
@@ -127,13 +127,13 @@ export const WishesListPage: React.FC = () => {
         />
         <Table.Column<WishUI>
           title="Public ?"
-          dataIndex="isPublic"
+          dataIndex="is_public"
           render={(value, record) => (
             <Switch
               checked={value}
               onChange={(val) =>
                 update(
-                  { resource: "wishes", id: record.id, values: { isPublic: val } },
+                  { resource: "wishes", id: record.id, values: { is_public: val } },
                   { onSuccess: () => message.success("C'est noté ✔️") }
                 )
               }

--- a/src/pages/wishes/wish-list-edit.page.tsx
+++ b/src/pages/wishes/wish-list-edit.page.tsx
@@ -3,16 +3,15 @@ import {
   EditButton,
   List,
   ShowButton,
-  useTable
+  useTable,
 } from "@refinedev/antd";
 import { useGetIdentity, useOne, useUpdate } from "@refinedev/core";
 import { Space, Switch, Table } from "antd";
 import { Link } from "react-router";
 import { UserIdentity, UserSlug } from "../../types";
+import type { Tables } from "../../../database.types";
 
-export type IWish = {
-  id: number;
-};
+export type IWish = Tables<"wishes">;
 
 
 export type IUser = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,5 @@
-export type User = {
-  id: string;
-};
+import type { Tables } from "../database.types";
 
-export type UserIdentity = User | null;
+export type UserIdentity = { id: string; role?: string } | null;
 
-export type UserSlug = {
-  created_at: string;
-  id: string;
-  slug: string;
-}
+export type UserSlug = Tables<"user_slugs">;

--- a/src/types/wish.ts
+++ b/src/types/wish.ts
@@ -1,26 +1,20 @@
+import type { Tables } from "../../database.types";
+
 export type WishStatus = "draft" | "available" | "reserved" | "received" | "archived";
 
-export type WishUI = {
-  id: string;
-  title: string;
-  description?: string;
-  url?: string;
-  price?: number;
+export type WishUI = Tables<"wishes"> & {
   currency?: "EUR" | "USD" | "GBP";
-  imageUrl?: string;
+  image_url?: string;
   quantity?: number;
   priority?: 1 | 2 | 3;
-  isPublic?: boolean;
   status?: WishStatus;
-  notePrivate?: string;
+  note_private?: string;
   tags?: string[];
   metadata?: {
-    siteName?: string;
+    site_name?: string;
     favicon?: string;
     title?: string;
   };
-  createdAt?: string;
-  updatedAt?: string;
 };
 
 export type WishExtraStore = Record<string, Partial<WishUI>>;

--- a/src/utility/mapDbToWishUI.test.ts
+++ b/src/utility/mapDbToWishUI.test.ts
@@ -4,12 +4,12 @@ import { getExtras, setExtras, removeExtras } from "./localExtrasStore";
 
 describe("mapDbToWishUI", () => {
   it("merges db row with extras, giving precedence to db", () => {
-    const dbRow = { id: "1", title: "db", price: 10 };
-    const extras = { price: 5, notePrivate: "secret", metadata: { foo: "bar" } };
+    const dbRow = { id: "1", name: "db", price: 10 };
+    const extras = { price: 5, note_private: "secret", metadata: { foo: "bar" } };
     const result = mapDbToWishUI(dbRow, extras);
-    expect(result.title).toBe("db");
+    expect(result.name).toBe("db");
     expect(result.price).toBe(10);
-    expect(result.notePrivate).toBe("secret");
+    expect(result.note_private).toBe("secret");
     expect(result.metadata?.foo).toBe("bar");
   });
 });
@@ -19,11 +19,11 @@ describe("localExtrasStore", () => {
     removeExtras("1");
   });
   it("stores and retrieves extras", () => {
-    setExtras("1", { notePrivate: "hello" });
-    expect(getExtras("1")).toEqual({ notePrivate: "hello" });
+    setExtras("1", { note_private: "hello" });
+    expect(getExtras("1")).toEqual({ note_private: "hello" });
   });
   it("removes extras", () => {
-    setExtras("1", { notePrivate: "hello" });
+    setExtras("1", { note_private: "hello" });
     removeExtras("1");
     expect(getExtras("1")).toEqual({});
   });

--- a/src/utility/supabaseClient.ts
+++ b/src/utility/supabaseClient.ts
@@ -1,10 +1,11 @@
 import { createClient } from "@refinedev/supabase";
+import type { Database } from "../../database.types";
 
 const SUPABASE_URL = "https://sxfqmmsawxxrafjfusdu.supabase.co";
 const SUPABASE_KEY =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN4ZnFtbXNhd3h4cmFmamZ1c2R1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQ0OTU2NDEsImV4cCI6MjA3MDA3MTY0MX0.AZ9MxVBGovMLGjsxJUVESbYDq3-Er7T7k1SV9qV4cdQ";
 
-export const supabaseClient = createClient(SUPABASE_URL, SUPABASE_KEY, {
+export const supabaseClient = createClient<Database>(SUPABASE_URL, SUPABASE_KEY, {
   db: {
     schema: "public",
   },


### PR DESCRIPTION
## Summary
- type Supabase client with generated Database types
- align wish and auth modules to strongly-typed schema
- document Supabase database usage

## Testing
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68a253740268832c8e98252017c305ba