### PR TITLE
Ensure wish list shows only current user’s wishes

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -14,6 +14,7 @@ This document tracks high-level technical decisions and UI guidelines for the pr
 - **Wish grid** displays a single column on small screens and switches to two columns from 400px width with generous gaps.
   - **WishCard** features a 4:3 image placeholder, subdued coral CTA, secondary link styling, and a reserved state badge.
   - See `admin-wishes-ui.md` for details on the administration CRUD interface including the redesigned creation wizard with a sticky action bar and mobile progress pills.
+- **Wishes List** filters Supabase queries by `user_id` to show only the signed-in user's wishes, preventing leakage of public wishes from other accounts.
 
 ## Accessibility
 - Interactive elements maintain a minimum touch area of 44px and include aria attributes for state changes.

--- a/src/pages/wishes/WishesListPage.tsx
+++ b/src/pages/wishes/WishesListPage.tsx
@@ -14,14 +14,31 @@ import {
   Space,
 } from "antd";
 import { useCreate, useUpdate } from "@refinedev/core";
+import { useGetIdentity } from "@refinedev/core";
 import { CreateWishWizard } from "../../components/admin/wishes/CreateWishWizard";
 import { EditWishDrawer } from "../../components/admin/wishes/EditWishDrawer";
 import { QuickAddBar } from "../../components/admin/wishes/QuickAddBar";
 import { WishUI } from "../../types/wish";
+import { UserIdentity } from "../../types";
 import { mapDbToWishUI, getExtras, setExtras } from "../../utility";
 
 export const WishesListPage: React.FC = () => {
-  const { tableProps } = useTable<WishUI>({ resource: "wishes" });
+  const { data: identity } = useGetIdentity<UserIdentity>();
+  const { tableProps } = useTable<WishUI>({
+    resource: "wishes",
+    queryOptions: {
+      enabled: !!identity,
+    },
+    filters: {
+      permanent: [
+        {
+          field: "user_id",
+          operator: "eq",
+          value: identity?.id,
+        },
+      ],
+    },
+  });
   const { mutate: update } = useUpdate();
   const { mutate: create } = useCreate();
 


### PR DESCRIPTION
## Summary
- filter `WishesListPage` queries by current user id
- document wish list filtering in project docs

## Testing
- `yarn test --run`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68a3564c9ba0832c857347613d791f90