### PR TITLE
Attach user id when creating wishes

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -18,7 +18,7 @@ This document tracks high-level technical decisions and UI guidelines for the pr
   - **WishCard** features a 4:3 image placeholder, subdued coral CTA, secondary link styling, and a reserved state badge.
   - See `admin-wishes-ui.md` for details on the administration CRUD interface including the redesigned creation wizard with a sticky action bar and mobile progress pills.
 - **Wishes List** filters Supabase queries by `user_id` to show only the signed-in user's wishes and renders a mobile-first list with image/placeholder, title, two-line description and a price formatted using the viewer's locale and currency. It handles skeleton loading, friendly empty and error states, and offers a single floating “+ Ajouter” button for creation.
- - **Add Wish Sheet** provides a bottom sheet/drawer with just four fields (Titre, Description, Prix+Devise, Lien) and warm microcopy. Drafts persist locally until submission. See `add-wish-sheet.md` for details.
+- **Add Wish Sheet** provides a bottom sheet/drawer with just four fields (Titre, Description, Prix+Devise, Lien) and warm microcopy. When a wish is saved, the current user's `user_id` is sent with the creation request so the record is linked to their account. Drafts persist locally until submission. See `add-wish-sheet.md` for details.
 
 ## Accessibility
 - Interactive elements maintain a minimum touch area of 44px and include aria attributes for state changes.

--- a/documentation/add-wish-sheet.md
+++ b/documentation/add-wish-sheet.md
@@ -11,5 +11,5 @@ A mobile-first bottom sheet (drawer on desktop) that lets users quickly add a wi
 All fields except the title are optional. Invalid links trigger a gentle warning but never block submission. Drafts persist in `localStorage` under `add-wish-draft` so unfinished entries survive accidental closure.
 
 ## Usage
-The component is opened from the floating “+” button on the wishes list. On save it shows the success toast “Souhait ajouté ✨” and refreshes the list. Errors display “Oups, on n’a pas pu enregistrer. Tes infos sont gardées en brouillon.”
+The component is opened from the floating “+” button on the wishes list. When submitted, it attaches the signed-in user's `user_id` to the new wish so it belongs to their account. On save it shows the success toast “Souhait ajouté ✨” and refreshes the list. Errors display “Oups, on n’a pas pu enregistrer. Tes infos sont gardées en brouillon.”
 

--- a/src/pages/wishes/WishesListPage.tsx
+++ b/src/pages/wishes/WishesListPage.tsx
@@ -208,9 +208,13 @@ export const WishesListPage: React.FC = () => {
   };
 
   const handleAdd = (values: WishUI) => {
+    if (!identity?.id) {
+      message.error("Impossible de créer le souhait : utilisateur inconnu");
+      return;
+    }
     const { note_private, tags, metadata, ...dbValues } = values;
     create(
-      { resource: "wishes", values: dbValues },
+      { resource: "wishes", values: { ...dbValues, user_id: identity.id } },
       {
         onSuccess: (data) => {
           if (data?.data?.id) {


### PR DESCRIPTION
## Summary
- include current user's `user_id` when creating a wish
- document wish creation behaviour

## Testing
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68a4d3483be4832c9f28645af56eafd9