### PR TITLE
Simplifie la modale d'édition des souhaits

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -16,7 +16,7 @@ This document tracks high-level technical decisions and UI guidelines for the pr
 - **Header** uses a light peach gradient and balanced title wrapping. The counter badge is centered beneath the subtitle.
 - **Wish grid** displays a single column on small screens and switches to two columns from 400px width with generous gaps.
   - **WishCard** features a 4:3 image placeholder, subdued coral CTA, secondary link styling, and a reserved state badge.
-  - See `admin-wishes-ui.md` for details on the administration CRUD interface including the redesigned creation wizard with a sticky action bar and mobile progress pills.
+  - See `admin-wishes-ui.md` for details on the administration CRUD interface including the redesigned creation wizard with a sticky action bar, mobile progress pills, and a minimalist edit drawer sharing the same fields.
 - **Wishes List** filters Supabase queries by `user_id` to show only the signed-in user's wishes and renders a mobile-first list with image/placeholder, title, two-line description and a price formatted using the viewer's locale and currency. It handles skeleton loading, friendly empty and error states, and offers a single floating “+ Ajouter” button for creation.
  - **Add Wish Sheet** provides a bottom sheet/drawer with just four fields (Titre, Description, Prix+Devise, Lien) and warm microcopy. Drafts persist locally until submission. See `add-wish-sheet.md` for details.
 

--- a/documentation/admin-wishes-ui.md
+++ b/documentation/admin-wishes-ui.md
@@ -4,7 +4,7 @@ This module provides a modern CRUD experience for managing wishes using React, R
 
  - **WishesListPage**: mobile‑first overview list showing a 56px image or 🎁 placeholder, title, two-line description and a price formatted from the browser's locale and currency. Each row is fully tappable and opens the EditWishDrawer. It includes skeleton loading, a friendly empty state and a retryable error state, with a single floating “+ Ajouter” button to create new wishes.
  - **CreateWishWizard**: responsive full‑screen modal. Desktop shows a two‑column layout with a vertical stepper and live WishCard preview. Mobile replaces the stepper with tappable progress pills. A sticky action bar keeps “Précédent”, “Suivant/Créer” and “Annuler” buttons always accessible.
-- **EditWishDrawer**: right-side drawer with tabs (Général, Détails, Visibilité) and an unsaved-changes guard.
+- **EditWishDrawer**: right-side drawer that reuses `WishForm`, offering the same fields as creation in a single minimalist view.
 - **useLinkMetadata hook**: fetches lightweight metadata for pasted URLs.
 - **mapDbToWishUI** and **localExtrasStore** utilities: merge Supabase rows with extras stored in `localStorage` and persist unsupported fields locally.
 

--- a/src/components/admin/wishes/EditWishDrawer.tsx
+++ b/src/components/admin/wishes/EditWishDrawer.tsx
@@ -1,19 +1,7 @@
-import { useEffect, useState } from "react";
-import {
-  Drawer,
-  Tabs,
-  Button,
-  Space,
-  Form,
-  Modal,
-  Typography,
-  Input,
-  InputNumber,
-  Select,
-  Switch,
-  Segmented,
-} from "antd";
+import { useState } from "react";
+import { Button, Drawer, Form, Space, Typography } from "antd";
 import { WishUI } from "../../../types/wish";
+import { WishForm } from "./WishForm";
 
 export type EditWishDrawerProps = {
   open: boolean;
@@ -31,31 +19,11 @@ export const EditWishDrawer: React.FC<EditWishDrawerProps> = ({
   const [form] = Form.useForm<WishUI>();
   const [saving, setSaving] = useState(false);
 
-  useEffect(() => {
-    if (open) {
-      form.resetFields();
-      if (initialValues) form.setFieldsValue(initialValues as any);
-    }
-  }, [open, initialValues, form]);
-
-  const handleClose = () => {
-    if (form.isFieldsTouched()) {
-      Modal.confirm({
-        title: "Des modifications non sauvegardées",
-        onOk: onClose,
-      });
-    } else {
-      onClose();
-    }
-  };
-
-  const submit = async () => {
+  const submit = async (values: WishUI) => {
+    setSaving(true);
     try {
-      const values = (await form.validateFields()) as WishUI;
-      setSaving(true);
       await onSave(values);
-      setSaving(false);
-    } catch {
+    } finally {
       setSaving(false);
     }
   };
@@ -65,90 +33,31 @@ export const EditWishDrawer: React.FC<EditWishDrawerProps> = ({
       width={520}
       open={open}
       destroyOnClose
-      onClose={handleClose}
+      onClose={onClose}
       title={
         <Space direction="vertical" size={0} style={{ width: "100%" }}>
           <Typography.Title level={4} style={{ margin: 0 }}>
             Éditer le souhait
           </Typography.Title>
           <Typography.Text type="secondary">
-            Peaufine ton souhait, on s'occupe du reste 💡
+            Modifie les informations de ton souhait
           </Typography.Text>
         </Space>
       }
       extra={
         <Space>
-          <Button onClick={handleClose}>Annuler</Button>
-          <Button type="primary" loading={saving} onClick={submit}>
+          <Button onClick={onClose}>Annuler</Button>
+          <Button
+            type="primary"
+            loading={saving}
+            onClick={() => form.submit()}
+          >
             Enregistrer
           </Button>
         </Space>
       }
     >
-      <Tabs
-        items={[
-          {
-            key: "general",
-            label: "Général",
-            children: (
-              <Form layout="vertical" form={form}>
-                <Form.Item name="name" label="Titre" rules={[{ required: true }]}> 
-                  <Input size="large" />
-                </Form.Item>
-                <Form.Item name="url" label="URL"> 
-                  <Input size="large" />
-                </Form.Item>
-                <Form.Item name="image_url" label="Image"> 
-                  <Input size="large" />
-                </Form.Item>
-              </Form>
-            ),
-          },
-          {
-            key: "details",
-            label: "Détails",
-            children: (
-              <Form layout="vertical" form={form}>
-                <Form.Item name="price" label="Prix">
-                  <InputNumber min={0} style={{ width: "100%" }} />
-                </Form.Item>
-                <Form.Item name="currency" label="Devise">
-                  <Select options={["EUR", "USD", "GBP"].map((v) => ({ value: v }))} />
-                </Form.Item>
-                <Form.Item name="description" label="Description">
-                  <Input.TextArea rows={3} />
-                </Form.Item>
-                <Form.Item name="quantity" label="Quantité">
-                  <InputNumber min={1} style={{ width: "100%" }} />
-                </Form.Item>
-                <Form.Item name="tags" label="Tags">
-                  <Select mode="tags" tokenSeparators={[","]} />
-                </Form.Item>
-                <Form.Item name="note_private" label="Note privée"> 
-                  <Input.TextArea rows={3} />
-                </Form.Item>
-                <Form.Item name="priority" label="Priorité">
-                  <Segmented options={[1, 2, 3]} />
-                </Form.Item>
-              </Form>
-            ),
-          },
-          {
-            key: "visibility",
-            label: "Visibilité",
-            children: (
-              <Form layout="vertical" form={form}>
-                <Form.Item name="status" label="Statut">
-                  <Select options={["draft", "available", "reserved", "received", "archived"].map((v) => ({ value: v }))} />
-                </Form.Item>
-                <Form.Item name="is_public" label="Public ?" valuePropName="checked">
-                  <Switch />
-                </Form.Item>
-              </Form>
-            ),
-          },
-        ]}
-      />
+      <WishForm form={form} initialValues={initialValues} onSubmit={submit} />
     </Drawer>
   );
 };


### PR DESCRIPTION
## Summary
- refactoriser la modale d'édition pour réutiliser `WishForm`
- mettre à jour la documentation de l'UI d'administration

## Testing
- `yarn build`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d499da70832c8a645ee8ffbd1430