### PR TITLE
Refresh wish list with colorful tokens and safe chips

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -7,6 +7,11 @@ This document tracks high-level technical decisions and UI guidelines for the pr
 - **Text primary:** `#1F2937`
 - **Text secondary:** `#6B7280`
 - **Header background:** `#FFF7F4`
+- **Accent peach:** `#FFE7E1`
+- **Accent mint:** `#E7FFF4`
+- **Accent lavender:** `#EFE7FF`
+- **Accent yellow:** `#FFF7D6`
+- **Separators:** `#EEF0F3`
 - **Radius:** `12px` for cards and images
 
 ## Theme

--- a/documentation/wishes-list-page.md
+++ b/documentation/wishes-list-page.md
@@ -8,20 +8,20 @@ Mobile-first list of the signed-in user's wishes with gentle prompts to encourag
 - When at least one wish exists, a count badge shows `{n} souhait(s)`.
 
 ## Rows
-- Full-width, minimum 64px height, and react to press with a light background and slight elevation.
-- Left: 56×56 image or 🎁 placeholder.
-- Center: one-line title then contextual hints:
-  - Description or fallback "Ajoute un petit mot pour guider 💌".
-  - If no link provided, extra line "+ Lien pour aider à trouver".
-- Right side pills:
-  - Domain pill when a link exists.
-  - Price pill or dashed "Ajouter un prix" pill.
-  - Chevron `›` to indicate navigation.
+- Full-width tap area, minimum 64px height. Pressing briefly highlights the row with a peach tint.
+- Left: 56×56 vignette with 12px radius.
+  - Priority: `image_url` → site favicon on a hashed pastel background → initial letter → category emoji.
+- Center: title on one line then a single meta-line:
+  - The domain chip (mint background) is always at the start when a link exists.
+  - Description or fallback "Ajoute un petit mot pour guider 💌" truncates to the right of the chip.
+  - If no link provided, an extra line "+ Lien pour aider à trouver" appears.
+- Right column: price pill (peach) or dashed "Ajouter un prix" pill. Chevron `›` signals navigation.
+- Layout rules prevent chips from overlapping and everything ellipsizes instead of wrapping.
 - Tapping any part opens the edit drawer, focusing the relevant field.
 
 ## Empty and Sparse States
 - Zero items: centered 🎁 with text "Aucun souhait pour l’instant. Ajoute ton premier ✨".
-- One or two items: two tappable ghost rows encouraging new wishes.
+- One or two items: two tappable ghost rows with pastel thumbnails inviting new wishes.
 
 ## Tip Bar
 - On first visit a dismissable tip appears: "Astuce : colle un lien Amazon/Etsy, on préremplit ✨".

--- a/src/pages/wishes/WishesListPage.tsx
+++ b/src/pages/wishes/WishesListPage.tsx
@@ -6,6 +6,7 @@ import {
   Tag,
   message,
 } from "antd";
+import { colors } from "../../theme";
 import {
   useGetIdentity,
   useList,
@@ -74,6 +75,106 @@ const Row: React.FC<RowProps> = ({ item, onOpen }) => {
   })();
   const [pressed, setPressed] = useState(false);
 
+  const accents = [
+    colors.accentPeach,
+    colors.accentMint,
+    colors.accentLavender,
+    colors.accentYellow,
+  ];
+
+  const hashColor = (seed: string) => {
+    let sum = 0;
+    for (let i = 0; i < seed.length; i++) sum += seed.charCodeAt(i);
+    return accents[sum % accents.length];
+  };
+
+  const getEmoji = (name?: string) => {
+    const n = (name || "").toLowerCase();
+    if (/livre|book/.test(n)) return "📚";
+    if (/tech|usb|phone|laptop|ordinateur|électronique/.test(n)) return "🔌";
+    if (/cuisine|kitchen|cook|casserole|poêle/.test(n)) return "🍳";
+    if (/maison|home|déco/.test(n)) return "🏠";
+    if (/pull|shirt|robe|vêt/.test(n)) return "👕";
+    return "🎁";
+  };
+
+  const renderThumb = () => {
+    const accent = hashColor(domain || item.name || "");
+    if (item.image_url) {
+      return (
+        <img
+          src={item.image_url}
+          alt=""
+          style={{
+            width: 56,
+            height: 56,
+            borderRadius: 12,
+            objectFit: "cover",
+            flexShrink: 0,
+          }}
+        />
+      );
+    }
+    if (item.metadata?.favicon) {
+      return (
+        <div
+          style={{
+            width: 56,
+            height: 56,
+            borderRadius: 12,
+            background: accent,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: 0,
+          }}
+        >
+          <img src={item.metadata.favicon} alt="" style={{ width: 24, height: 24 }} />
+        </div>
+      );
+    }
+    const emoji = getEmoji(item.name);
+    if (emoji !== "🎁") {
+      return (
+        <div
+          style={{
+            width: 56,
+            height: 56,
+            borderRadius: 12,
+            background: accent,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: 0,
+            fontSize: 24,
+          }}
+        >
+          {emoji}
+        </div>
+      );
+    }
+    const initial = item.name?.[0]?.toUpperCase() || "?";
+    return (
+      <div
+        style={{
+          width: 56,
+          height: 56,
+          borderRadius: 12,
+          background: accent,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+          fontSize: 24,
+          fontWeight: 600,
+          color: colors.textPrimary,
+        }}
+      >
+        {initial}
+      </div>
+    );
+  };
+
   const handleClick = () => {
     if (navigator.vibrate) navigator.vibrate(10);
     onOpen(item);
@@ -94,47 +195,18 @@ const Row: React.FC<RowProps> = ({ item, onOpen }) => {
         alignItems: "center",
         minHeight: 64,
         padding: "12px 0",
-        borderBottom: "1px solid #F0F2F5",
-        background: pressed ? "#FAFAFA" : undefined,
-        boxShadow: pressed ? "0 1px 2px rgba(0,0,0,0.05)" : undefined,
+        borderBottom: "1px solid #EEF0F3",
+        background: pressed ? colors.accentPeach : undefined,
         cursor: "pointer",
       }}
     >
-      {item.image_url ? (
-        <img
-          src={item.image_url}
-          alt=""
-          style={{
-            width: 56,
-            height: 56,
-            borderRadius: 12,
-            objectFit: "cover",
-            flexShrink: 0,
-          }}
-        />
-      ) : (
-        <div
-          style={{
-            width: 56,
-            height: 56,
-            borderRadius: 12,
-            background: "#F6F7F9",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            flexShrink: 0,
-            fontSize: 24,
-          }}
-        >
-          🎁
-        </div>
-      )}
+      {renderThumb()}
       <div style={{ flex: 1, marginLeft: 12, overflow: "hidden" }}>
         <div
           style={{
             fontWeight: 600,
             fontSize: 16,
-            color: "#1F2937",
+            color: colors.textPrimary,
             whiteSpace: "nowrap",
             overflow: "hidden",
             textOverflow: "ellipsis",
@@ -144,26 +216,50 @@ const Row: React.FC<RowProps> = ({ item, onOpen }) => {
         </div>
         <div
           style={{
-            fontSize: 14,
-            color: "#6B7280",
-            lineHeight: 1.35,
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+            whiteSpace: "nowrap",
             overflow: "hidden",
-            display: "-webkit-box",
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: "vertical",
-          }}
-          onClick={(e) => {
-            e.stopPropagation();
-            onOpen(item, "description");
           }}
         >
-          {item.description || "Ajoute un petit mot pour guider 💌"}
+          {domain && (
+            <Tag
+              style={{
+                background: colors.accentMint,
+                border: "none",
+                color: colors.textPrimary,
+                flexShrink: 0,
+                cursor: "pointer",
+              }}
+              onClick={(e) => {
+                e.stopPropagation();
+                onOpen(item, "url");
+              }}
+            >
+              {domain}
+            </Tag>
+          )}
+          <span
+            style={{
+              fontSize: 14,
+              color: colors.textSecondary,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+            onClick={(e) => {
+              e.stopPropagation();
+              onOpen(item, "description");
+            }}
+          >
+            {item.description || "Ajoute un petit mot pour guider 💌"}
+          </span>
         </div>
         {!domain && (
           <div
             style={{
               fontSize: 14,
-              color: "#6B7280",
+              color: colors.textSecondary,
               marginTop: 4,
             }}
             onClick={(e) => {
@@ -175,25 +271,14 @@ const Row: React.FC<RowProps> = ({ item, onOpen }) => {
           </div>
         )}
       </div>
-      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-        {domain && (
-          <Tag
-            style={{ cursor: "pointer" }}
-            onClick={(e) => {
-              e.stopPropagation();
-              onOpen(item, "url");
-            }}
-          >
-            {domain}
-          </Tag>
-        )}
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginLeft: 8 }}>
         {price ? (
           <Tag
             style={{
-              background: "#F3F4F6",
+              background: colors.accentPeach,
               border: "none",
               fontWeight: 600,
-              color: "#111827",
+              color: colors.textPrimary,
               cursor: "pointer",
             }}
             onClick={(e) => {
@@ -206,9 +291,9 @@ const Row: React.FC<RowProps> = ({ item, onOpen }) => {
         ) : (
           <Tag
             style={{
-              background: "transparent",
-              border: "1px dashed #D1D5DB",
-              color: "#6B7280",
+              background: colors.accentPeach,
+              border: `1px dashed ${colors.primary}`,
+              color: colors.primary,
               cursor: "pointer",
             }}
             onClick={(e) => {
@@ -389,7 +474,7 @@ export const WishesListPage: React.FC = () => {
                 display: "flex",
                 alignItems: "center",
                 padding: "12px 0",
-                borderBottom: "1px solid #F0F2F5",
+                borderBottom: "1px solid #EEF0F3",
               }}
             >
               <Skeleton.Avatar
@@ -463,7 +548,7 @@ export const WishesListPage: React.FC = () => {
                     display: "flex",
                     alignItems: "center",
                     padding: "12px 0",
-                    borderBottom: "1px solid #F0F2F5",
+                    borderBottom: "1px solid #EEF0F3",
                     cursor: "pointer",
                     minHeight: 64,
                   }}
@@ -473,17 +558,18 @@ export const WishesListPage: React.FC = () => {
                       width: 56,
                       height: 56,
                       borderRadius: 12,
-                      background: "#F6F7F9",
+                      background: i % 2 === 0 ? colors.accentPeach : colors.accentMint,
                       display: "flex",
                       alignItems: "center",
                       justifyContent: "center",
                       flexShrink: 0,
                       fontSize: 24,
+                      color: colors.primary,
                     }}
                   >
                     +
                   </div>
-                  <div style={{ marginLeft: 12, color: "#6B7280" }}>{placeholder}</div>
+                  <div style={{ marginLeft: 12, color: colors.textSecondary }}>{placeholder}</div>
                 </div>
               ))}
             </>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -19,6 +19,10 @@ export const colors = {
   textPrimary: '#1F2937',
   textSecondary: '#6B7280',
   primary: '#FF6B6B',
+  accentPeach: '#FFE7E1',
+  accentMint: '#E7FFF4',
+  accentLavender: '#EFE7FF',
+  accentYellow: '#FFF7D6',
   success: '#4caf50',
   reservedBg: '#f5f5f5',
 } as const;


### PR DESCRIPTION
## Summary
- add pastel accent tokens to theme
- redesign wish list rows with hashed vignette backgrounds, domain chip and dedicated price column
- document new palette and list layout

## Testing
- `yarn test run`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68a4e46ad514832caea0a5050b2747e8