### PR TITLE
Prevent iOS auto zoom and stabilise mobile sheet

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -27,6 +27,9 @@ This document tracks high-level technical decisions and UI guidelines for the pr
 
 ## Accessibility
 - Interactive elements maintain a minimum touch area of 44px and include aria attributes for state changes.
+- Form controls default to a 16px font size to avoid iOS Safari's automatic zoom. Placeholders and select values match this size.
+- The global viewport is `width=device-width, initial-scale=1, viewport-fit=cover`. Bottom sheets temporarily append `maximum-scale=1` while open to suppress pinch-zoom then restore the original viewport.
+- Scroll containers inside sheets use `overscroll-behavior: contain` to prevent accidental pull-to-refresh.
 
 ## Database
 Supabase Postgres powers persistence. Types are generated with `npx supabase gen types typescript --project-id $SUPABASE_PROJECT_ID --schema public > database.types.ts` and imported across the codebase to ensure queries match the schema.

--- a/documentation/add-wish-sheet.md
+++ b/documentation/add-wish-sheet.md
@@ -10,6 +10,12 @@ A mobile-first bottom sheet (drawer on desktop) that lets users quickly add a wi
 
 All fields except the title are optional. Invalid links trigger a gentle warning but never block submission. Drafts persist in `localStorage` under `add-wish-draft` so unfinished entries survive accidental closure.
 
+### Mobile considerations
+- Every input and select renders at a minimum of 16px so iOS Safari never auto-zooms on focus.
+- The price field uses a text input with `inputmode="decimal"` and an inline currency selector to avoid native number steppers.
+- While the sheet is open a `maximum-scale=1` attribute is temporarily added to the viewport meta tag to prevent pinch-zoom and is restored on close.
+- The drawer body applies `overscroll-behavior: contain` to block pull-to-refresh gestures.
+
 ## Usage
 The component is opened from the floating “+” button on the wishes list. When submitted, it attaches the signed-in user's `user_id` to the new wish so it belongs to their account. On save it shows the success toast “Souhait ajouté ✨” and refreshes the list. Errors display “Oups, on n’a pas pu enregistrer. Tes infos sont gardées en brouillon.”
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
     <meta name="theme-color" content="#ffffff" />
     <meta name="color-scheme" content="light" />
     <meta

--- a/src/components/wish/AddWishSheet.tsx
+++ b/src/components/wish/AddWishSheet.tsx
@@ -1,5 +1,15 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Drawer, Form, Input, InputNumber, Button, Select, Space, Tag, Typography, message } from "antd";
+import {
+  Drawer,
+  Form,
+  Input,
+  Button,
+  Select,
+  Space,
+  Tag,
+  Typography,
+  message,
+} from "antd";
 import type { InputRef } from "antd";
 import { useMediaQuery } from "@mui/material";
 import type { WishUI } from "../../types/wish";
@@ -19,6 +29,7 @@ export const AddWishSheet: React.FC<AddWishSheetProps> = ({ open, onCancel, onSu
   const [linkDomain, setLinkDomain] = useState<string | null>(null);
   const [showPasteTip, setShowPasteTip] = useState(false);
   const linkInputRef = useRef<InputRef | null>(null);
+  const initialViewport = useRef<string | null>(null);
 
   const url = Form.useWatch("url", form);
   const { metadata } = useLinkMetadata(url ?? undefined);
@@ -47,6 +58,24 @@ export const AddWishSheet: React.FC<AddWishSheetProps> = ({ open, onCancel, onSu
       setShowPasteTip(false);
     }
   }, [open, form]);
+
+  useEffect(() => {
+    const metaViewport = document.querySelector(
+      'meta[name="viewport"]'
+    ) as HTMLMetaElement | null;
+    if (!metaViewport) return;
+    if (initialViewport.current === null) {
+      initialViewport.current = metaViewport.getAttribute("content") || "";
+    }
+    if (open) {
+      metaViewport.setAttribute(
+        "content",
+        `${initialViewport.current}, maximum-scale=1`
+      );
+    } else {
+      metaViewport.setAttribute("content", initialViewport.current);
+    }
+  }, [open]);
 
   useEffect(() => {
     if (metadata && !form.getFieldValue("name")) {
@@ -106,7 +135,12 @@ export const AddWishSheet: React.FC<AddWishSheetProps> = ({ open, onCancel, onSu
       width={isMobile ? undefined : 360}
       title="Ajouter un souhait 🎁"
       extra={<span style={{ color: "#6B7280" }}>Note l’essentiel, tu pourras peaufiner après.</span>}
-      bodyStyle={{ display: "flex", flexDirection: "column", paddingBottom: 0 }}
+      bodyStyle={{
+        display: "flex",
+        flexDirection: "column",
+        paddingBottom: 0,
+        overscrollBehavior: "contain",
+      }}
     >
       {isMobile && (
         <div
@@ -132,7 +166,10 @@ export const AddWishSheet: React.FC<AddWishSheetProps> = ({ open, onCancel, onSu
           rules={[{ required: true, min: 2, message: "Un titre est requis" }]}
           extra="Un nom clair aide tes proches à choisir."
         >
-          <Input placeholder="Bouilloire inox silencieuse" />
+          <Input
+            placeholder="Bouilloire inox silencieuse"
+            style={{ fontSize: 16 }}
+          />
         </Form.Item>
 
         <Form.Item
@@ -143,6 +180,7 @@ export const AddWishSheet: React.FC<AddWishSheetProps> = ({ open, onCancel, onSu
           <Input.TextArea
             placeholder="Pourquoi ça me ferait plaisir ? Une petite note pour guider (couleur, taille, usage…)."
             autoSize={{ minRows: 3, maxRows: 4 }}
+            style={{ fontSize: 16 }}
           />
         </Form.Item>
 
@@ -151,20 +189,21 @@ export const AddWishSheet: React.FC<AddWishSheetProps> = ({ open, onCancel, onSu
           label="Prix"
           extra="Indique un budget pour faciliter le choix."
         >
-          <Space.Compact>
-            <InputNumber
-              min={0}
-              style={{ width: "100%" }}
-              placeholder="0"
-            />
-            <Form.Item name="currency" initialValue="EUR" noStyle>
-              <Select style={{ width: 80 }}>
-                <Select.Option value="EUR">EUR</Select.Option>
-                <Select.Option value="GBP">GBP</Select.Option>
-                <Select.Option value="USD">USD</Select.Option>
-              </Select>
-            </Form.Item>
-          </Space.Compact>
+          <Input
+            type="text"
+            inputMode="decimal"
+            placeholder="0"
+            style={{ fontSize: 16 }}
+            addonAfter={
+              <Form.Item name="currency" initialValue="EUR" noStyle>
+                <Select style={{ width: 80, fontSize: 16 }}>
+                  <Select.Option value="EUR">EUR</Select.Option>
+                  <Select.Option value="GBP">GBP</Select.Option>
+                  <Select.Option value="USD">USD</Select.Option>
+                </Select>
+              </Form.Item>
+            }
+          />
         </Form.Item>
 
         <Form.Item name="url" label="Lien" extra="Ajoute un lien pour aider à trouver le bon produit.">
@@ -174,9 +213,11 @@ export const AddWishSheet: React.FC<AddWishSheetProps> = ({ open, onCancel, onSu
               placeholder="https://amazon.fr/… (ou autre site)"
               inputMode="url"
               onChange={handleLinkChange}
-              style={{ flex: 1 }}
+              style={{ flex: 1, fontSize: 16 }}
             />
-            <Button onClick={handlePaste}>Coller</Button>
+            <Button onClick={handlePaste} style={{ fontSize: 16 }}>
+              Coller
+            </Button>
           </Space>
           {showPasteTip && (
             <Typography.Text type="secondary">

--- a/src/global.css
+++ b/src/global.css
@@ -1,0 +1,19 @@
+html {
+  -webkit-text-size-adjust: 100%;
+}
+
+input,
+textarea,
+select,
+.ant-input,
+.ant-select-selector,
+.ant-select-selection-item,
+.ant-select-selection-placeholder {
+  font-size: 16px !important;
+}
+
+input::placeholder,
+textarea::placeholder,
+.ant-select-selection-placeholder {
+  font-size: 16px !important;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 
 import App from "./App";
+import "./global.css";
 
 const container = document.getElementById("root") as HTMLElement;
 const root = createRoot(container);


### PR DESCRIPTION
## Summary
- prevent iOS Safari zoom by enforcing 16px control fonts and temporary viewport lock
- replace number input with decimal text field and inline currency selector
- document mobile sheet behavior and global viewport setup

## Testing
- `yarn test --run`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68a4eeff46d4832ca7e638e93c79d3d8