### PR TITLE
feat: add lightweight public gift page

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -20,10 +20,13 @@ This document tracks high-level technical decisions and UI guidelines for the pr
 ## Components
 - **Header** uses a light peach gradient and balanced title wrapping. The counter badge is centered beneath the subtitle.
 - **Wish grid** displays a single column on small screens and switches to two columns from 400px width with generous gaps.
+  - **GiftTile** is used on public lists with a 56px thumbnail, domain pill and price aligned to the right. Reserved tiles show a "✅ Réservé" badge and are inactive.
   - **WishCard** features a 4:3 image placeholder, subdued coral CTA, secondary link styling, and a reserved state badge.
   - See `admin-wishes-ui.md` for details on the administration CRUD interface including the redesigned creation wizard with a sticky action bar and mobile progress pills.
 - **Wishes List** filters Supabase queries by `user_id` to show only the signed-in user's wishes and renders a mobile-first list with image/placeholder, chevron and tappable rows. Each row shows a title, contextual prompts for missing description, link and price pills or placeholders. A count badge appears in the header, the first visit shows a dismissable clipboard tip and up to two ghost rows encourage adding more wishes. A visible “Voir la liste publique” button with Share/Copy support links to `/l/{slug}` and an info banner appears if no wish is public. Skeleton loading, friendly empty/error states and a single centered “+” FAB round out the experience. See `wishes-list-page.md` for details.
 - **Add Wish Sheet** provides a bottom sheet/drawer with just four fields (Titre, Description, Prix+Devise, Lien) and warm microcopy. When a wish is saved, the current user's `user_id` is sent with the creation request so the record is linked to their account. Drafts persist locally until submission. See `add-wish-sheet.md` for details.
+
+- See `public-gift-page.md` for the public gifting experience available at `/l/:slug`.
 
 ## Accessibility
 - Interactive elements maintain a minimum touch area of 44px and include aria attributes for state changes.

--- a/documentation/public-gift-page.md
+++ b/documentation/public-gift-page.md
@@ -1,0 +1,16 @@
+# Public Gift Page
+
+The public gifting page (`/l/:slug`) presents a lightweight, mobile-first interface for contributors. It loads in under a second and keeps interaction to a minimum.
+
+## Layout
+- **Header:** compact hero with share and "Créer ma liste" actions. A counter chip displays remaining unreserved gifts.
+- **Gift grid:** responsive 1–2 column grid of `GiftTile` components. Tiles are tappable rows with a 56px thumbnail, title and domain pill. Reserved items show a "✅ Réservé" badge and become inactive.
+- **Bottom sheet:** selecting a tile opens a sheet with the gift details and a single primary action. A secondary link allows proposing an alternative link. The caption "On garde la surprise 🤫" reinforces the surprise.
+- **Footer callout:** soft prompt linking to `/wishes` for creating one's own list.
+
+## Interactions
+- **Share:** uses the Web Share API when available, otherwise copies the page URL and shows a "Lien copié ✨" toast.
+- **Reserve:** instantly confirms with a "Réservé ! Merci 💝" toast.
+
+## Accessibility
+- Interactive targets are at least 44px high and include keyboard handlers. Ant Design's drawer provides focus trapping for the bottom sheet.

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export { Header } from "./header";
 export { WishCard } from "./wish/WishCard";
+export { GiftTile } from "./wish/GiftTile";
 export { ReserveBottomSheet } from "./wish/ReserveBottomSheet";
 export type { Wish } from "./wish/types";

--- a/src/components/wish/GiftTile.css
+++ b/src/components/wish/GiftTile.css
@@ -1,0 +1,83 @@
+.gift-tile {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid #eef0f3;
+  border-radius: 12px;
+  background-color: #fff;
+  cursor: pointer;
+  position: relative;
+}
+
+.gift-tile.reserved {
+  filter: saturate(0.6);
+  pointer-events: none;
+}
+
+.thumb {
+  width: 56px;
+  height: 56px;
+  border-radius: 12px;
+  overflow: hidden;
+  background-color: #f3f4f6;
+  flex-shrink: 0;
+}
+
+.thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #ffe7e1, #fff);
+  color: #ff6b6b;
+  font-weight: 600;
+  font-size: 20px;
+}
+
+.content {
+  flex: 1;
+  min-width: 0;
+}
+
+.title {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: #6b7280;
+  margin-top: 4px;
+}
+
+.domain-pill {
+  background: #eef0f3;
+  padding: 2px 8px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.price {
+  margin-left: auto;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.reserved-badge {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+}

--- a/src/components/wish/GiftTile.test.tsx
+++ b/src/components/wish/GiftTile.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { GiftTile } from "./GiftTile";
+import type { Wish } from "./types";
+
+const base: Wish = { id: 1, name: "Livre", url: "https://example.com" };
+
+describe("GiftTile", () => {
+  it("renders title and domain", () => {
+    render(<GiftTile wish={base} />);
+    expect(screen.getByText("Livre")).toBeInTheDocument();
+    expect(screen.getByText("example.com")).toBeInTheDocument();
+  });
+
+  it("shows reserved state", () => {
+    render(<GiftTile wish={{ ...base, isReserved: true }} />);
+    expect(screen.getByText(/Réservé/)).toBeInTheDocument();
+  });
+});

--- a/src/components/wish/GiftTile.tsx
+++ b/src/components/wish/GiftTile.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { Tag } from "antd";
+import type { Wish } from "./types";
+import "./GiftTile.css";
+
+interface GiftTileProps {
+  wish: Wish;
+  onSelect?: (wish: Wish) => void;
+}
+
+const getDomain = (url?: string | null) => {
+  if (!url) return "";
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return "";
+  }
+};
+
+const getThumb = (wish: Wish): string | null => {
+  if (wish.image) return wish.image;
+  if (wish.url) {
+    const domain = getDomain(wish.url);
+    if (domain) {
+      return `https://www.google.com/s2/favicons?domain=${domain}`;
+    }
+  }
+  return null;
+};
+
+export const GiftTile: React.FC<GiftTileProps> = ({ wish, onSelect }) => {
+  const domain = getDomain(wish.url);
+  const thumb = getThumb(wish);
+
+  const handleClick = () => {
+    if (!wish.isReserved) {
+      onSelect?.(wish);
+    }
+  };
+
+  return (
+    <div
+      className={`gift-tile${wish.isReserved ? " reserved" : ""}`}
+      onClick={handleClick}
+      role="button"
+      tabIndex={0}
+      onKeyPress={(e) => {
+        if (e.key === "Enter") handleClick();
+      }}
+    >
+      <div className="thumb">
+        {thumb ? (
+          <img src={thumb} alt="" />
+        ) : (
+          <div className="placeholder" aria-hidden>
+            {wish.name.charAt(0)}
+          </div>
+        )}
+      </div>
+      <div className="content">
+        <div className="title" title={wish.name}>
+          {wish.name}
+        </div>
+        <div className="meta">
+          {domain && <span className="domain-pill">{domain}</span>}
+          {wish.description && <span className="note">{wish.description}</span>}
+          {wish.price && <span className="price">{wish.price}</span>}
+        </div>
+      </div>
+      {wish.isReserved && (
+        <Tag color="success" className="reserved-badge">
+          ✅ Réservé
+        </Tag>
+      )}
+    </div>
+  );
+};
+

--- a/src/components/wish/ReserveBottomSheet.css
+++ b/src/components/wish/ReserveBottomSheet.css
@@ -1,0 +1,38 @@
+.sheet-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.sheet-thumb {
+  width: 56px;
+  height: 56px;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #f3f4f6;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sheet-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.sheet-price {
+  font-weight: 600;
+}
+
+.sheet-domain {
+  color: #ff6b6b;
+}
+
+.sheet-caption {
+  text-align: center;
+  color: #6b7280;
+  margin-top: 8px;
+}

--- a/src/components/wish/ReserveBottomSheet.tsx
+++ b/src/components/wish/ReserveBottomSheet.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Button, Drawer, Form, Input, message } from "antd";
 import type { Wish } from "./types";
+import "./ReserveBottomSheet.css";
 
 interface ReserveBottomSheetProps {
   open: boolean;
@@ -17,7 +18,7 @@ export const ReserveBottomSheet: React.FC<ReserveBottomSheetProps> = ({
   const [form] = Form.useForm();
 
   const handleReserve = () => {
-    message.success("Réservé ! Merci 🤍 On garde la surprise.");
+    message.success("Réservé ! Merci 💝");
     onClose();
   };
 
@@ -36,49 +37,56 @@ export const ReserveBottomSheet: React.FC<ReserveBottomSheetProps> = ({
       height="auto"
       destroyOnClose
       title={wish?.name}
-      extra={mode === "propose" ? null : (
-        <Button type="link" onClick={switchToPropose}>
-          Je veux plutôt proposer un autre lien
-        </Button>
-      )}
     >
-      <p>On garde la surprise 🤫</p>
-      <Form
-        layout="vertical"
-        form={form}
-        onFinish={mode === "reserve" ? handleReserve : handlePropose}
-      >
-        {mode === "reserve" && (
-          <>
-            <Form.Item name="name" label="Prénom">
-              <Input />
-            </Form.Item>
-            <Form.Item name="email" label="Email">
-              <Input type="email" />
-            </Form.Item>
-            <Form.Item>
-              <Button type="primary" htmlType="submit" block>
-                Confirmer la réservation
-              </Button>
-            </Form.Item>
-          </>
-        )}
-        {mode === "propose" && (
-          <>
-            <Form.Item name="url" label="Lien">
-              <Input type="url" />
-            </Form.Item>
-            <Form.Item name="note" label="Note">
-              <Input />
-            </Form.Item>
-            <Form.Item>
-              <Button type="primary" htmlType="submit" block>
-                Envoyer
-              </Button>
-            </Form.Item>
-          </>
-        )}
-      </Form>
+      {wish && (
+        <div className="sheet-content">
+          <div className="sheet-thumb">
+            {wish.image ? (
+              <img src={wish.image} alt="" />
+            ) : (
+              <span className="placeholder">{wish.name.charAt(0)}</span>
+            )}
+          </div>
+          {wish.price && <div className="sheet-price">{wish.price}</div>}
+          {wish.url && (
+            <a
+              href={wish.url}
+              className="sheet-domain"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {new URL(wish.url).hostname.replace(/^www\./, "")}
+            </a>
+          )}
+          {wish.description && <p>{wish.description}</p>}
+        </div>
+      )}
+      {mode === "reserve" && (
+        <>
+          <Button type="primary" block onClick={handleReserve}>
+            Réserver
+          </Button>
+          <Button type="link" block onClick={switchToPropose}>
+            Proposer un autre lien
+          </Button>
+          <p className="sheet-caption">On garde la surprise 🤫</p>
+        </>
+      )}
+      {mode === "propose" && (
+        <Form layout="vertical" form={form} onFinish={handlePropose}>
+          <Form.Item name="url" label="Lien">
+            <Input type="url" />
+          </Form.Item>
+          <Form.Item name="note" label="Note">
+            <Input />
+          </Form.Item>
+          <Form.Item>
+            <Button type="primary" htmlType="submit" block>
+              Envoyer
+            </Button>
+          </Form.Item>
+        </Form>
+      )}
     </Drawer>
   );
 };

--- a/src/pages/wishes/public-wishlist.page.css
+++ b/src/pages/wishes/public-wishlist.page.css
@@ -4,14 +4,22 @@
 }
 
 .wishlist-header {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
   background: linear-gradient(#FFF7F4, #FFFFFF);
   padding: 24px 16px;
   border-radius: 0 0 12px 12px;
   margin-bottom: 24px;
+}
+
+.header-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.titles {
+  flex: 1;
+  text-align: center;
 }
 
 .wishlist-header h1 {
@@ -25,9 +33,31 @@
   margin: 8px 0 0;
 }
 
+.header-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.action {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px;
+  min-height: 44px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 14px;
+  border-radius: 8px;
+}
+
+.action span {
+  margin-left: 4px;
+}
+
 .wishlist-header .counter {
   border-radius: 999px;
-  margin-top: 8px;
+  margin: 12px auto 0;
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -36,7 +66,7 @@
 
 .wish-grid {
   display: grid;
-  gap: 20px;
+  gap: 16px;
   grid-template-columns: 1fr;
 }
 
@@ -47,5 +77,22 @@
 }
 
 .wish-skeleton {
-  height: 260px;
+  padding: 12px;
+  border: 1px solid #eef0f3;
+  border-radius: 12px;
+}
+
+.wishlist-footer {
+  margin-top: 32px;
+  text-align: center;
+  font-size: 14px;
+}
+
+.wishlist-footer a {
+  color: #ff6b6b;
+}
+
+.empty {
+  text-align: center;
+  margin-top: 40px;
 }

--- a/src/pages/wishes/public-wishlist.page.tsx
+++ b/src/pages/wishes/public-wishlist.page.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 import { useParams } from "react-router";
 import { useList } from "@refinedev/core";
-import { Tag, Skeleton } from "antd";
-import { WishCard, ReserveBottomSheet } from "../../components";
+import { Tag, Skeleton, message } from "antd";
+import { GiftTile, ReserveBottomSheet } from "../../components";
 import type { Wish } from "../../components";
 import "./public-wishlist.page.css";
 
@@ -27,44 +27,74 @@ export const PublicWishlistPage: React.FC = () => {
   const remaining = wishes.filter((w) => !w.isReserved).length;
   const [selected, setSelected] = useState<Wish | null>(null);
 
+  const firstName = slug ? slug.split("-")[0] : "";
+
+  const handleShare = async () => {
+    const url = window.location.href;
+    try {
+      if (navigator.share) {
+        await navigator.share({ url });
+      } else {
+        await navigator.clipboard.writeText(url);
+        message.success("Lien copié ✨");
+      }
+    } catch {
+      /* noop */
+    }
+  };
+
   return (
     <div className="public-wishlist">
       <header className="wishlist-header">
-        <h1>Anniversaire de Ismael 🎂</h1>
-        <p className="subtitle">Choisis ce qui fera plaisir 💝</p>
+        <div className="header-top">
+          <div className="titles">
+            <h1>Anniversaire de {firstName} 🎂</h1>
+            <p className="subtitle">Choisis ce qui fera plaisir 💝</p>
+          </div>
+          <div className="header-actions">
+            <button className="action" onClick={handleShare}>
+              📤<span>Partager</span>
+            </button>
+            <a className="action" href="/wishes">
+              ✏️<span>Créer ma liste</span>
+            </a>
+          </div>
+        </div>
         <Tag className="counter">
-          <span role="img" aria-label="cadeau">
-            🎁
-          </span>
-          {" "}
-          {remaining} cadeaux restants
+          <span role="img" aria-label="cadeau">🎁</span> {remaining} cadeaux restants
         </Tag>
       </header>
-      <div className="wish-grid">
-        {isLoading
-          ? Array.from({ length: 4 }).map((_, i) => (
-              <Skeleton.Button
-                key={i}
-                active
-                className="wish-skeleton"
-                shape="round"
-                block
-              />
-            ))
-          : wishes.map((w) => (
-              <WishCard
-                key={w.id}
-                wish={w}
-                onReserve={setSelected}
-                onProposeLink={setSelected}
-              />
-            ))}
-      </div>
+
+      {remaining === 0 && wishes.length > 0 ? (
+        <p className="empty">Tout est réservé 🎉 Merci ! Tu peux encore faire une surprise.</p>
+      ) : (
+        <div className="wish-grid">
+          {isLoading
+            ? Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton
+                  key={i}
+                  active
+                  avatar={{ shape: "square", size: 56 }}
+                  title={{ width: "60%" }}
+                  paragraph={false}
+                  className="wish-skeleton"
+                />
+              ))
+            : wishes.map((w) => (
+                <GiftTile key={w.id} wish={w} onSelect={setSelected} />
+              ))}
+        </div>
+      )}
+
       <ReserveBottomSheet
         open={!!selected}
         wish={selected}
         onClose={() => setSelected(null)}
       />
+
+      <footer className="wishlist-footer">
+        <a href="/wishes">Envie de ta propre wishlist ? Créer ma liste</a>
+      </footer>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- introduce compact GiftTile component with domain pill and reserved badge
- redesign public wishlist with share, create list actions, and footer callout
- streamline reservation sheet and document public gifting flow

## Testing
- `npm run build` *(fails: Cannot find module '@refinedev/core' and other type declarations)*
- `yarn test` *(fails: vitest run did not complete in container)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f2b00e30832ca0f4e7cf52d12c34