### PR TITLE
Fix mobile add wish bottom sheet overlay and scroll handling

### DIFF
--- a/documentation/add-wish-sheet.md
+++ b/documentation/add-wish-sheet.md
@@ -16,6 +16,12 @@ All fields except the title are optional. Invalid links trigger a gentle warning
 - While the sheet is open a `maximum-scale=1` attribute is temporarily added to the viewport meta tag to prevent pinch-zoom and is restored on close.
 - The drawer body applies `overscroll-behavior: contain` to block pull-to-refresh gestures.
 
+### Overlay and layering
+- The sheet and its overlay render in a portal attached to `document.body`.
+- A fixed mask with ~50% opacity covers the page and captures all clicks; the sheet panel sits above the mask with a higher `z-index`.
+- When open the document body is scroll-locked and the admin header loses its sticky positioning so nothing bleeds through.
+- Dropdowns like the currency selector render inside the sheet with an even higher `z-index` to appear above the header and footer.
+
 ## Usage
 The component is opened from the floating “+” button on the wishes list. When submitted, it attaches the signed-in user's `user_id` to the new wish so it belongs to their account. On save it shows the success toast “Souhait ajouté ✨” and refreshes the list. Errors display “Oups, on n’a pas pu enregistrer. Tes infos sont gardées en brouillon.”
 


### PR DESCRIPTION
## Summary
- lock body scroll and drop header z-index when add-wish sheet is open
- render sheet in portal with fixed mask and high z-index
- document bottom sheet overlay and layering behaviour

## Testing
- `yarn build`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68a4f78e10cc832c97d0aeed8350742d