### PR TITLE
fix: stack add wish header vertically

### DIFF
--- a/documentation/add-wish-sheet.md
+++ b/documentation/add-wish-sheet.md
@@ -2,6 +2,9 @@
 
 A mobile-first bottom sheet (drawer on desktop) that lets users quickly add a wish with minimal friction.
 
+## Header
+The header stacks a short title and subtitle vertically with a small gap. The title truncates after two lines with an ellipsis and sits above a secondary colored subtitle. On mobile a centered drag handle appears above the text. The layout avoids any absolute positioning or negative margins, ensuring no overlap even when the title wraps.
+
 ## Fields
 1. **Titre** – required, placeholder "Bouilloire inox silencieuse" with inline help.
 2. **Description** – multiline, placeholder: "Pourquoi ça me ferait plaisir ? Une petite note pour guider (couleur, taille, usage…)."

--- a/src/components/wish/AddWishSheet.tsx
+++ b/src/components/wish/AddWishSheet.tsx
@@ -161,8 +161,59 @@ export const AddWishSheet: React.FC<AddWishSheetProps> = ({ open, onCancel, onSu
       placement={isMobile ? "bottom" : "right"}
       height={isMobile ? "90vh" : undefined}
       width={isMobile ? undefined : 360}
-      title="Ajouter un souhait"
-      extra={<span style={{ color: "#6B7280" }}>Note l’essentiel, tu pourras peaufiner après.</span>}
+      title={
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 8,
+            width: "100%",
+          }}
+        >
+          {isMobile && (
+            <div
+              style={{
+                width: 40,
+                height: 4,
+                background: "#ccc",
+                borderRadius: 2,
+                margin: "0 auto",
+              }}
+            />
+          )}
+          <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            <Typography.Title
+              level={4}
+              style={{
+                margin: 0,
+                lineHeight: 1.2,
+                fontSize: "clamp(20px, 5vw, 22px)",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                display: "-webkit-box",
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: "vertical",
+              }}
+            >
+              Ajouter un souhait
+            </Typography.Title>
+            <Typography.Text
+              style={{
+                margin: 0,
+                lineHeight: 1.35,
+                color: "#6B7280",
+                display: "block",
+                fontSize: 16,
+                whiteSpace: "normal",
+                wordBreak: "normal",
+                overflowWrap: "anywhere",
+              }}
+            >
+              Note l’essentiel, tu pourras peaufiner après.
+            </Typography.Text>
+          </div>
+        </div>
+      }
       headerStyle={{
         background: "#fff",
         borderBottom: "1px solid #f0f0f0",
@@ -187,17 +238,6 @@ export const AddWishSheet: React.FC<AddWishSheetProps> = ({ open, onCancel, onSu
         background: "#fff",
       }}
     >
-      {isMobile && (
-        <div
-          style={{
-            width: 40,
-            height: 4,
-            background: "#ccc",
-            borderRadius: 2,
-            margin: "8px auto",
-          }}
-        />
-      )}
       <Form
         layout="vertical"
         form={form}


### PR DESCRIPTION
## Summary
- avoid overlapping add wish sheet title and subtitle
- document stacked header layout

## Testing
- `yarn test`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68a750b990d8832c86c6bc2c24e21959