### PR TITLE
Disable default notifications and document custom toasts

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -25,6 +25,11 @@ This document tracks high-level technical decisions and UI guidelines for the pr
   - **Wishes List** filters Supabase queries by `user_id` to show only the signed-in user's wishes and renders a mobile-first list with image/placeholder, chevron and tappable rows. Each row shows a title, contextual prompts for missing description, link and price pills or placeholders. A count badge appears in the header and up to two ghost rows encourage adding more wishes. When at least one wish is public, external-link and share icon buttons in the header link to `/l/{slug}` and trigger the native share sheet or copy the link. A dismissable info banner reminds the user to make wishes public when none are. Skeleton loading, friendly empty/error states and a single centered “+” FAB round out the experience. Long press on a row reveals an inline **Supprimer → Confirmer** chip with undoable deletion. See `wishes-list-page.md` for details.
 - **Add Wish Sheet** provides a bottom sheet/drawer with just four fields (Titre, Description, Prix+Devise, Lien) and warm microcopy. When a wish is saved, the current user's `user_id` is sent with the creation request so the record is linked to their account. Drafts persist locally until submission. See `add-wish-sheet.md` for details.
 
+## Notifications
+- Built-in Refine snackbars are disabled so only our custom toasts appear.
+- Success and error messages use Ant Design's `message` API (e.g. "Souhait ajouté ✨").
+- Mutations opt out of library notifications with `successNotification: false` and `errorNotification: false`. See `notifications.md` for guidance.
+
 ## Accessibility
 - Interactive elements maintain a minimum touch area of 44px and include aria attributes for state changes.
 - Form controls default to a 16px font size to avoid iOS Safari's automatic zoom. Placeholders and select values match this size.

--- a/documentation/notifications.md
+++ b/documentation/notifications.md
@@ -1,0 +1,9 @@
+# Notifications
+
+Fast Wishes relies on custom Ant Design toasts and disables automatic messages from Refine.
+
+- The `Refine` app runs without a `notificationProvider`, preventing default snackbars like "Success".
+- Mutations such as `useCreate`, `useUpdate` and `useDelete` pass `successNotification: false` and `errorNotification: false`.
+- User feedback is provided through `message.success`, `message.error` and `message.open` with our own copy (e.g. "Souhait ajouté ✨").
+
+This ensures a single, consistent toast per action.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,7 @@
 import { Authenticated, Refine } from "@refinedev/core";
 import { RefineKbar, RefineKbarProvider } from "@refinedev/kbar";
 
-import {
-  RefineSnackbarProvider,
-  useNotificationProvider,
-} from "@refinedev/mui";
+import { RefineThemes } from "@refinedev/mui";
 
 import CssBaseline from "@mui/material/CssBaseline";
 import GlobalStyles from "@mui/material/GlobalStyles";
@@ -24,7 +21,6 @@ import { theme } from "./theme";
 import { supabaseClient } from "./utility";
 import { smartDataProvider } from "./providers/smartDataProvider";
 import { WishesListPage } from "./pages/wishes/WishesListPage";
-import { RefineThemes } from "@refinedev/mui";
 
 function App() {
   return (
@@ -34,13 +30,11 @@ function App() {
         <ThemeProvider theme={RefineThemes.Blue}>
           <CssBaseline />
           <GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto", colorScheme: "light" } }} />
-          <RefineSnackbarProvider>
               <Refine
                   dataProvider={smartDataProvider}
                   liveProvider={liveProvider(supabaseClient)}
                 authProvider={authProvider}
                 routerProvider={routerBindings}
-                notificationProvider={useNotificationProvider}
                 options={{
                   warnWhenUnsavedChanges: true,
                   useNewQueryKeys: true,
@@ -70,7 +64,6 @@ function App() {
                 <UnsavedChangesNotifier />
                 <DocumentTitleHandler />
               </Refine>
-          </RefineSnackbarProvider>
         </ThemeProvider>
       </RefineKbarProvider>
       </ConfigProvider>

--- a/src/pages/wishes/WishesListPage.tsx
+++ b/src/pages/wishes/WishesListPage.tsx
@@ -495,7 +495,13 @@ export const WishesListPage: React.FC = () => {
     if (!editing) return;
     const { note_private, tags, metadata, ...dbValues } = values;
     update(
-      { resource: "wishes", id: editing.id, values: dbValues },
+      {
+        resource: "wishes",
+        id: editing.id,
+        values: dbValues,
+        successNotification: false,
+        errorNotification: false,
+      },
       {
         onSuccess: () => {
           setExtras(String(editing.id), { note_private, tags, metadata });
@@ -518,7 +524,12 @@ export const WishesListPage: React.FC = () => {
     }
     const { note_private, tags, metadata, ...dbValues } = values;
     create(
-      { resource: "wishes", values: { ...dbValues, user_id: identity.id } },
+      {
+        resource: "wishes",
+        values: { ...dbValues, user_id: identity.id },
+        successNotification: false,
+        errorNotification: false,
+      },
       {
         onSuccess: (data) => {
           if (data?.data?.id) {
@@ -570,7 +581,12 @@ export const WishesListPage: React.FC = () => {
     });
     const timeout = window.setTimeout(() => {
       deleteOne(
-        { resource: "wishes", id: wish.id },
+        {
+          resource: "wishes",
+          id: wish.id,
+          successNotification: false,
+          errorNotification: false,
+        },
         {
           onError: () => {
             undo();


### PR DESCRIPTION
## Summary
- remove Refine's snackbar provider to stop automatic success messages
- opt out of Refine's notifications on wish mutations and keep our `message` toasts
- document notification approach

## Testing
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68a774e6f654832c8e21498e3be28f80