### PR TITLE
docs: document supabase CLI env vars and type generation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -35,6 +35,19 @@ Refine's hooks and components simplifies the development process and eliminates 
     yarn start
 ```
 
+## Supabase CLI
+
+The Supabase CLI relies on two environment variables:
+
+- `SUPABASE_PROJECT_ID` – your project identifier
+- `SUPABASE_KEY` – the service role key for the project
+
+Before starting any task, regenerate the database types to keep them in sync:
+
+```bash
+npx supabase gen types typescript --project-id $SUPABASE_PROJECT_ID --schema public > database.types.ts
+```
+
 ## Learn More
 
 To learn more about **Refine**, please check out the [Documentation](https://refine.dev/docs)

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -37,7 +37,16 @@ This document tracks high-level technical decisions and UI guidelines for the pr
 - Scroll containers inside sheets use `overscroll-behavior: contain` to prevent accidental pull-to-refresh.
 
 ## Database
-Supabase Postgres powers persistence. Types are generated with `npx supabase gen types typescript --project-id $SUPABASE_PROJECT_ID --schema public > database.types.ts` and imported across the codebase to ensure queries match the schema.
+Supabase Postgres powers persistence. The Supabase CLI requires two environment variables:
+
+- `SUPABASE_PROJECT_ID` – your project identifier
+- `SUPABASE_KEY` – the service role key used by the CLI
+
+Before starting any task, regenerate the database types to keep them in sync:
+
+`npx supabase gen types typescript --project-id $SUPABASE_PROJECT_ID --schema public > database.types.ts`
+
+The resulting `database.types.ts` file is imported across the codebase to ensure queries match the schema.
 
 ## Build
 - The project builds via `tsc && vite build` to ensure compatibility with Yarn PnP.


### PR DESCRIPTION
## Summary
- document SUPABASE_PROJECT_ID and SUPABASE_KEY env vars
- instruct running Supabase type generation before each task

## Testing
- `yarn build` *(fails: Cannot find module '@ant-design/icons')*
- `yarn test` *(fails: Failed to resolve import "country-to-currency")*

------
https://chatgpt.com/codex/tasks/task_e_68a825a8762c832cb067838c2fa01349