### PR TITLE
feat: integrate Amazon Product Advertising API for search

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -47,9 +47,10 @@ Before starting any task, regenerate the database types to keep them in sync:
 `npx supabase gen types typescript --project-id $SUPABASE_PROJECT_ID --schema public > database.types.ts`
 
 The resulting `database.types.ts` file is imported across the codebase to ensure queries match the schema.
-
 ## Edge Functions
+
 - **enrich-wish** fetches basic metadata for a supplied URL to prefill wish details. See `wish-enrichment-edge-function.md` for implementation notes.
+- **search-amazon** uses Amazon's Product Advertising API to return a list of products matching a query. See `amazon-product-search-edge-function.md` for implementation notes.
 - Edge functions deploy automatically to Supabase when commits land on `main` via the `deploy-edge-functions.yml` GitHub workflow.
 
 ## Build

--- a/documentation/amazon-product-search-edge-function.md
+++ b/documentation/amazon-product-search-edge-function.md
@@ -1,0 +1,54 @@
+# Amazon Product Search Edge Function
+
+The `search-amazon` Supabase Edge Function uses Amazon's official Product
+Advertising API to search for products and returns a list of basic details. It
+is invoked from the client using `supabaseClient.functions.invoke()`.
+
+## Deployment
+The function deploys automatically to the production project. Every push to the
+`main` branch triggers the `deploy-edge-functions.yml` workflow, which runs
+`supabase functions deploy search-amazon` using the `SUPABASE_PROJECT_ID` and
+`SUPABASE_ACCESS_TOKEN` secrets.
+
+## Environment Variables
+
+The function expects the following Amazon credentials to be set:
+
+- `AMAZON_ACCESS_KEY`
+- `AMAZON_SECRET_KEY`
+- `AMAZON_PARTNER_TAG`
+
+## Request
+
+```json
+{
+  "query": "Nintendo Switch",
+  "limit": 3
+}
+```
+
+## Response
+
+```json
+{
+  "items": [
+    {
+      "asin": "B0GHVJF",
+      "title": "Nintendo Switch",
+      "image": "https://.../image.jpg",
+      "price": 299,
+      "url": "https://www.amazon.com/dp/B0GHVJF"
+    },
+    {
+      "asin": "B0ABCDEF",
+      "title": "Another Product",
+      "image": "https://.../image2.jpg",
+      "price": 199,
+      "url": "https://www.amazon.com/dp/B0ABCDEF"
+    }
+  ]
+}
+```
+
+The response contains up to `limit` results. Fields may be `undefined` when the
+information is missing from the API response.

--- a/supabase/functions/search-amazon/index.ts
+++ b/supabase/functions/search-amazon/index.ts
@@ -1,0 +1,101 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import aws4 from "npm:aws4";
+
+export const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+interface Payload {
+  query?: string;
+  limit?: number;
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return new Response("Method not allowed", {
+      headers: corsHeaders,
+      status: 405,
+    });
+  }
+
+  try {
+    const { query, limit } = (await req.json()) as Payload;
+    if (!query) {
+      return new Response(JSON.stringify({ error: "Missing query" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json", ...corsHeaders },
+      });
+    }
+
+    const accessKey = Deno.env.get("AMAZON_ACCESS_KEY");
+    const secretKey = Deno.env.get("AMAZON_SECRET_KEY");
+    const partnerTag = Deno.env.get("AMAZON_PARTNER_TAG");
+    if (!accessKey || !secretKey || !partnerTag) {
+      return new Response(
+        JSON.stringify({ error: "Missing Amazon API credentials" }),
+        {
+          status: 500,
+          headers: {
+            "Content-Type": "application/json",
+            ...corsHeaders,
+          },
+        },
+      );
+    }
+
+    const body = JSON.stringify({
+      Keywords: query,
+      SearchIndex: "All",
+      ItemCount: limit ?? 5,
+      PartnerTag: partnerTag,
+      PartnerType: "Associates",
+      Resources: [
+        "ItemInfo.Title",
+        "Images.Primary.Medium",
+        "Offers.Listings.Price",
+      ],
+    });
+
+    const opts = {
+      host: "webservices.amazon.com",
+      path: "/paapi5/searchitems",
+      service: "ProductAdvertisingAPI",
+      region: "us-east-1",
+      method: "POST",
+      body,
+      headers: {
+        "Content-Type": "application/json; charset=UTF-8",
+      },
+    } as aws4.Request;
+
+    aws4.sign(opts, { accessKeyId: accessKey, secretAccessKey: secretKey });
+
+    const apiRes = await fetch(`https://${opts.host}${opts.path}`, opts);
+    const data = await apiRes.json();
+
+    const items =
+      data.SearchResult?.Items?.map((item: any) => ({
+        asin: item.ASIN,
+        title: item.ItemInfo?.Title?.DisplayValue,
+        image: item.Images?.Primary?.Medium?.URL,
+        price: item.Offers?.Listings?.[0]?.Price?.Amount,
+        url: item.DetailPageURL,
+      })) ?? [];
+
+    return new Response(JSON.stringify({ items }), {
+      headers: { "Content-Type": "application/json", ...corsHeaders },
+    });
+  } catch (e) {
+    return new Response(JSON.stringify({ error: String(e) }), {
+      status: 500,
+      headers: { "Content-Type": "application/json", ...corsHeaders },
+    });
+  }
+});
+


### PR DESCRIPTION
## Summary
- replace HTML scraping with official Amazon Product Advertising API
- return a list of matching products instead of a single item
- document search function and required credentials

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68acc0b96dd8832c83a1e26e98c2a4a5