### PR TITLE
Fix default locale and wishes redirect

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -58,11 +58,11 @@ The resulting `database.types.ts` file is imported across the codebase to ensure
 
 ## Internationalization
 - Translations are handled with **i18next** and **react-i18next** with an ICU plugin for plurals.
-- Supported locales: `fr`, `en`, and a stretching `pseudo` locale. Invalid locales redirect to French.
-- Language is detected from the URL path, then cookie, local storage, and browser settings. Preference persists in both cookie and `localStorage`.
+- Supported locales: `fr`, `en`, and a stretching `pseudo` locale. Invalid locales redirect to English.
+- Language is detected from the URL path, cookie, local storage, then browser settings (`navigator.language`). Preference persists in both cookie and `localStorage`. English is the fallback when no preference can be determined.
 - Translation namespaces (`common.json`) load on demand via dynamic imports.
 - The top-level router uses paths like `/:locale/*` and updates `<html lang>` accordingly.
-- Unprefixed URLs (e.g. `/wishes`) redirect to the detected locale: `/fr/wishes` by default.
+- The root path `/` and other unprefixed URLs redirect to the detected locale's wishes page (e.g. `/fr/wishes`).
 - The `useFormat` helper exposes `formatPrice`, `formatNumber`, and `formatDate` using the active locale via `Intl`.
 - Run `yarn check:i18n` in CI to ensure French and English keys remain in sync.
 - All user-facing components rely on semantic translation keys stored in `common.json` for French, English and pseudo locales.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,8 +28,9 @@ import { fallbackLng } from "./i18n/config";
 
 function RootRedirect() {
   const { pathname, search, hash } = useLocation();
-  const target = i18n.resolvedLanguage || fallbackLng;
-  return <Navigate to={`/${target}${pathname}${search}${hash}`} replace />;
+  const target = i18n.language || fallbackLng;
+  const suffix = pathname === "/" ? "/wishes" : pathname;
+  return <Navigate to={`/${target}${suffix}${search}${hash}`} replace />;
 }
 
 function App() {

--- a/src/components/wish/WishCard.test.tsx
+++ b/src/components/wish/WishCard.test.tsx
@@ -1,11 +1,15 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { WishCard } from "./WishCard";
 import type { Wish } from "./types";
+import { changeLocale } from "../../i18n";
 
 const baseWish: Wish = { id: 1, name: "Vélo" };
 
 describe("WishCard", () => {
+  beforeAll(async () => {
+    await changeLocale("fr");
+  });
   it("renders title", () => {
     render(<WishCard wish={baseWish} />);
     expect(screen.getByText("Vélo")).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Detect browser locale before redirecting and keep English as fallback
- Redirect unknown locales to English and document detection order

## Testing
- `yarn vitest run --reporter=basic`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b16305b4fc832c99ba3e6a7549c068