### PR TITLE
feat: add translation usage check

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -65,6 +65,7 @@ The resulting `database.types.ts` file is imported across the codebase to ensure
 - Unprefixed URLs (e.g. `/wishes`) redirect to the detected locale: `/fr/wishes` by default.
 - The `useFormat` helper exposes `formatPrice`, `formatNumber`, and `formatDate` using the active locale via `Intl`.
 - Run `yarn check:i18n` in CI to ensure French and English keys remain in sync.
+- Run `yarn check:translations` to verify every `t("...")` key used in source code exists in all locale files.
 - All user-facing components rely on semantic translation keys stored in `common.json` for French, English and pseudo locales.
 
 ## Branding

--- a/documentation/translation-check.md
+++ b/documentation/translation-check.md
@@ -1,0 +1,3 @@
+# Translation Usage Check
+
+`scripts/check-translations.mjs` scans the `src` directory for `t("...")` calls and ensures each key exists in the `fr` and `en` locale files under `src/i18n/locales`. Run `yarn check:translations` to catch missing entries before committing.

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "start": "refine start",
     "test": "vitest",
     "check:i18n": "node scripts/check-i18n.mjs",
+    "check:translations": "node scripts/check-translations.mjs",
     "refine": "refine"
   },
   "browserslist": {

--- a/scripts/check-translations.mjs
+++ b/scripts/check-translations.mjs
@@ -1,0 +1,65 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+function collect(obj, prefix = '', acc = []) {
+  for (const key of Object.keys(obj)) {
+    const val = obj[key];
+    const next = prefix ? `${prefix}.${key}` : key;
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      collect(val, next, acc);
+    } else {
+      acc.push(next);
+    }
+  }
+  return acc;
+}
+
+const locales = ['fr', 'en'];
+const localeDir = path.resolve('src/i18n/locales');
+const localeKeys = {};
+for (const lng of locales) {
+  const file = path.join(localeDir, lng, 'common.json');
+  const json = JSON.parse(readFileSync(file, 'utf-8'));
+  localeKeys[lng] = new Set(collect(json));
+}
+
+function walk(dir, acc = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (['node_modules', '.yarn', 'dist'].includes(entry.name)) continue;
+      walk(path.join(dir, entry.name), acc);
+    } else if (/\.(ts|tsx|js|jsx)$/.test(entry.name)) {
+      acc.push(path.join(dir, entry.name));
+    }
+  }
+  return acc;
+}
+
+const files = walk(path.resolve('src'));
+const keyRegex = /\bt\(\s*["'`]([^"'`]+)["'`]/g;
+const usedKeys = new Set();
+for (const file of files) {
+  const content = readFileSync(file, 'utf-8');
+  for (const match of content.matchAll(keyRegex)) {
+    if (!match[1].includes('${')) {
+      usedKeys.add(match[1]);
+    }
+  }
+}
+
+const missing = [];
+for (const key of usedKeys) {
+  for (const lng of locales) {
+    if (!localeKeys[lng].has(key)) {
+      missing.push(`${key} (${lng})`);
+    }
+  }
+}
+
+if (missing.length) {
+  console.error('Missing translations found:');
+  for (const m of missing) console.error(`  - ${m}`);
+  process.exit(1);
+}
+
+console.log('All used translations are present.');


### PR DESCRIPTION
## Summary
- add script to detect missing translation keys used via `t("...")`
- document translation check tooling

## Testing
- `yarn check:translations`
- `yarn check:i18n`
- `yarn build`
- `yarn test` *(fails: Unable to find an element with the text /Réservé/)*

------
https://chatgpt.com/codex/tasks/task_e_68b159d0fc5c832c809811666e15a8d2