### PR TITLE
fix: allow anonymous public wishlist access

### DIFF
--- a/documentation/public-wishlist-page.md
+++ b/documentation/public-wishlist-page.md
@@ -1,0 +1,18 @@
+# Public Wishlist Page
+
+Displays a user's public wishes without requiring a pre-existing session. The page
+is reachable at `/{locale}/l/{slug}` and shows wishes marked as public for the
+specified user.
+
+## Anonymous Access
+- Visitors are logged in anonymously before data is fetched.
+- This prevents the router from redirecting to the authenticated wishes page and
+  allows fetching data from Supabase.
+
+## Data Fetching
+- Uses `useList` on the `wishes` resource with filters:
+  - `user_slugs.slug` equals the URL's `slug` parameter.
+  - `is_public` equals `true`.
+- Selects `*, user_slugs!inner(slug)` to access the slug within the result set.
+
+

--- a/src/i18n/LocaleGate.tsx
+++ b/src/i18n/LocaleGate.tsx
@@ -53,9 +53,11 @@ export const LocaleGate: React.FC = () => {
           <Route path="new-wish" element={<NewWishPage />} />
         </Routes>
       </Authenticated>
-      <Routes>
-        <Route path="l/:slug" element={<PublicWishlistPage />} />
-      </Routes>
+      <Authenticated key="public" fallback={<AnonymousLogin />}>
+        <Routes>
+          <Route path="l/:slug" element={<PublicWishlistPage />} />
+        </Routes>
+      </Authenticated>
       <RefineKbar />
       <UnsavedChangesNotifier />
       <DocumentTitleHandler />


### PR DESCRIPTION
## Summary
- ensure public wishlist route logs visitors in anonymously
- document public wishlist page behavior

## Testing
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b2bad76698832cba6a891d29365263