### PR TITLE
Bundle translations in production build

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -60,7 +60,7 @@ The resulting `database.types.ts` file is imported across the codebase to ensure
 - Translations are handled with **i18next** and **react-i18next** with an ICU plugin for plurals.
 - Supported locales: `fr`, `en`, and a stretching `pseudo` locale. Invalid locales redirect to English.
 - Language is detected from the URL path, cookie, local storage, then browser settings (`navigator.language`). Preference persists in both cookie and `localStorage`. English is the fallback when no preference can be determined.
-- Translation namespaces (`common.json`) load on demand via dynamic imports.
+- Translation namespaces (`common.json`) load on demand using `import.meta.glob`, ensuring the locale files are bundled in production.
 - The top-level router uses paths like `/:locale/*` and updates `<html lang>` accordingly.
 - The root path `/` and other unprefixed URLs redirect to the detected locale's wishes page (e.g. `/fr/wishes`).
 - The `useFormat` helper exposes `formatPrice`, `formatNumber`, and `formatDate` using the active locale via `Intl`.

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -2,8 +2,14 @@ export const supportedLngs = ["fr", "en", "pseudo"] as const;
 export type Locale = typeof supportedLngs[number];
 export const fallbackLng: Locale = "en";
 
+const localeFiles = import.meta.glob<Record<string, string>>("./locales/*/common.json");
+
 export const loadLocale = async (lng: Locale) => {
-  const module = await import(/* @vite-ignore */ `./locales/${lng}/common.json`);
+  const importer = localeFiles[`./locales/${lng}/common.json`];
+  if (!importer) {
+    throw new Error(`Locale ${lng} not found`);
+  }
+  const module = await importer();
   return module.default;
 };
 


### PR DESCRIPTION
## Summary
- ensure locale JSON is bundled by switching to `import.meta.glob`
- document translation bundling strategy

## Testing
- `yarn test`
- `yarn check:i18n`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b2be95aa48832cbe36d0998c4c916a