### PR TITLE
Add baby wishlist demo page

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -29,6 +29,7 @@ This document tracks high-level technical decisions and UI guidelines for the pr
 
 - **Wish Sheet** is a unified bottom sheet/drawer used to add or edit a wish. It captures title, price with currency, a single merchant link field with paste button and inline domain/title preview, personal comment and priority chips. The currency defaults to `guessUserCurrency()` which reads the profile, prior wishes or browser locale via `country-to-currency` and falls back to USD. The currency dropdown portals to `document.body` with a high `z-index` and prevents `mousedown` blur so options remain tappable. When a wish is saved the user's `user_id` is attached and the sheet closes with a single success toast. All copy is sourced from the i18n bundles. See `wish-sheet.md` for details.
 - **Public wishlist** at `/l/{slug}` uses `PublicWishCard` to render each wish with a 56px image or emoji avatar on the left, text details with price beneath and an inline reserve button. See `public-wishlist-page.md` for specifics.
+- **Baby wishlist demo** at `/en/demo/baby-wishlist` is a static, login-free showcase aimed at parents-to-be campaigns. It uses curated `PublicWishCard` entries with Unsplash imagery, English copy, and a hero banner for clean marketing screenshots. See `demo-baby-wishlist.md` for layout and usage notes.
 
 ## Notifications
 - Built-in Refine snackbars are disabled so only our custom toasts appear.

--- a/documentation/demo-baby-wishlist.md
+++ b/documentation/demo-baby-wishlist.md
@@ -1,0 +1,19 @@
+# Demo baby wishlist page
+
+The baby registry demo lives at `/en/demo/baby-wishlist`. It is a static, login-free page designed for marketing screenshots aimed at parents-to-be.
+
+## Purpose
+- Provide a clean English wishlist example that avoids exposing real user data.
+- Highlight share-ready copy for baby shower or birth list campaigns.
+- Offer multi-image cards to show the carousel controls in action.
+
+## Implementation
+- **Route:** Declared in `src/App.tsx` as `demo/baby-wishlist` under the locale-aware router.
+- **Page:** `src/pages/demo/BabyWishlistDemoPage.tsx` assembles a curated set of `PublicWishCard` components with baby-focused items (crib, monitor, carrier, sound machine, newborn kit).
+- **Styling:** `src/pages/demo/BabyWishlistDemoPage.css` lays out a two-column hero header and a responsive wish grid with pill tags for quick campaign notes.
+- **Data:** Uses static `Wish` objects with demo owner IDs, price/currency, optional links, and Unsplash image URLs to keep the layout rich without hitting Supabase.
+
+## How to use
+1. Open `/en/demo/baby-wishlist` in the deployed app or locally while the dev server runs.
+2. Capture the hero + grid for ads or landing pages; the copy is already English-first.
+3. Share the link directly—authentication is not required for this route.

--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -11,6 +11,7 @@ import { BrowserRouter, Navigate, Route, Routes, useLocation } from "react-route
 import i18n from "./i18n";
 import { LocaleGate, ProtectedOutlet } from "./i18n/LocaleGate";
 import { fallbackLng } from "./i18n/config";
+import { BabyWishlistDemoPage } from "./pages/demo/BabyWishlistDemoPage";
 import { WishesListPage } from "./pages/wishes/WishesListPage";
 import { PublicWishlistPage } from "./pages/wishes/public-wishlist.page";
 import { theme } from "./theme";
@@ -33,6 +34,7 @@ function App() {
               <GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto", colorScheme: "light" } }} />
               <Routes>
                 <Route path=":locale" element={<LocaleGate />}>
+                  <Route path="demo/baby-wishlist" element={<BabyWishlistDemoPage />} />
                   <Route element={<ProtectedOutlet />}>
                     <Route path="wishes" element={<WishesListPage />} />
                     <Route path="l/:slug" element={<PublicWishlistPage />} />

--- a/packages/webapp/src/pages/demo/BabyWishlistDemoPage.css
+++ b/packages/webapp/src/pages/demo/BabyWishlistDemoPage.css
@@ -1,0 +1,80 @@
+.demo-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 48px 20px 72px;
+  color: #0f172a;
+}
+
+.demo-hero {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 24px;
+  align-items: center;
+  margin-bottom: 32px;
+}
+
+.demo-hero h1 {
+  margin: 4px 0 12px;
+  font-size: 40px;
+  line-height: 1.1;
+}
+
+.demo-hero .lead {
+  font-size: 18px;
+  max-width: 720px;
+  margin: 0 0 16px;
+  color: #334155;
+}
+
+.demo-hero .eyebrow {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: #8b5cf6;
+  margin: 0;
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.pill {
+  background: #f4f5fb;
+  border: 1px solid #e5e7eb;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-weight: 600;
+}
+
+.hero-note {
+  background: linear-gradient(135deg, #f8fafc, #eef2ff);
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 16px 18px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.08);
+  font-size: 14px;
+  max-width: 280px;
+}
+
+.hero-note p {
+  margin: 0 0 4px;
+  color: #475569;
+}
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+@media (max-width: 900px) {
+  .demo-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .demo-hero h1 {
+    font-size: 32px;
+  }
+}

--- a/packages/webapp/src/pages/demo/BabyWishlistDemoPage.tsx
+++ b/packages/webapp/src/pages/demo/BabyWishlistDemoPage.tsx
@@ -1,0 +1,187 @@
+import { Tag } from "antd";
+import React from "react";
+import { PublicWishCard } from "../../components";
+import type { Wish } from "../../components";
+import "./BabyWishlistDemoPage.css";
+
+const demoOwnerId = "demo-baby-parent";
+
+const demoWishes: Wish[] = [
+  {
+    id: 101,
+    name: "Convertible crib with organic mattress",
+    description: "Greenguard-certified crib that turns into a toddler bed to grow with baby.",
+    price: "399",
+    currency: "USD",
+    status: "available",
+    is_public: true,
+    is_reserved: false,
+    price_is_approx: false,
+    priority: 1,
+    tag: "nursery",
+    url: "https://example.com/crib",
+    created_at: "2024-12-01T10:00:00Z",
+    user_id: demoOwnerId,
+    emoji: "🛏️",
+    images: [
+      {
+        id: 201,
+        created_at: "2024-12-01T10:00:00Z",
+        wish_id: 101,
+        storage_object_name: "demo/crib.jpg",
+        url: "https://images.unsplash.com/photo-1504151932400-72d4384f04b3?auto=format&fit=crop&w=800&q=80",
+      },
+    ],
+  },
+  {
+    id: 102,
+    name: "Video baby monitor with night vision",
+    description: "Secure HD monitor with breathing alerts and a flexible floor stand.",
+    price: "249",
+    currency: "USD",
+    status: "available",
+    is_public: true,
+    is_reserved: false,
+    price_is_approx: false,
+    priority: 1,
+    tag: "tech",
+    url: "https://example.com/monitor",
+    created_at: "2024-12-01T10:05:00Z",
+    user_id: demoOwnerId,
+    emoji: "📡",
+    images: [
+      {
+        id: 202,
+        created_at: "2024-12-01T10:05:00Z",
+        wish_id: 102,
+        storage_object_name: "demo/monitor.jpg",
+        url: "https://images.unsplash.com/photo-1582719478248-54e9f2af4c93?auto=format&fit=crop&w=800&q=80",
+      },
+      {
+        id: 203,
+        created_at: "2024-12-01T10:06:00Z",
+        wish_id: 102,
+        storage_object_name: "demo/monitor-detail.jpg",
+        url: "https://images.unsplash.com/photo-1527443224154-d7aa3ffda1c4?auto=format&fit=crop&w=800&q=80",
+      },
+    ],
+  },
+  {
+    id: 103,
+    name: "Ergonomic baby carrier",
+    description: "Breathable mesh carrier that supports newborns up to 33 lbs with hip-healthy positioning.",
+    price: "189",
+    currency: "USD",
+    status: "available",
+    is_public: true,
+    is_reserved: false,
+    price_is_approx: false,
+    priority: 2,
+    tag: "on-the-go",
+    url: "https://example.com/carrier",
+    created_at: "2024-12-01T10:10:00Z",
+    user_id: demoOwnerId,
+    emoji: "🤱",
+    images: [
+      {
+        id: 204,
+        created_at: "2024-12-01T10:10:00Z",
+        wish_id: 103,
+        storage_object_name: "demo/carrier.jpg",
+        url: "https://images.unsplash.com/photo-1495197359483-d092478c170a?auto=format&fit=crop&w=800&q=80",
+      },
+    ],
+  },
+  {
+    id: 104,
+    name: "Smart sound machine",
+    description: "White noise, lullabies, and sunrise light to help baby wind down and wake gently.",
+    price: "89",
+    currency: "USD",
+    status: "available",
+    is_public: true,
+    is_reserved: false,
+    price_is_approx: false,
+    priority: 2,
+    tag: "sleep",
+    url: "https://example.com/sound-machine",
+    created_at: "2024-12-01T10:15:00Z",
+    user_id: demoOwnerId,
+    emoji: "🎶",
+    images: [
+      {
+        id: 205,
+        created_at: "2024-12-01T10:15:00Z",
+        wish_id: 104,
+        storage_object_name: "demo/sound-machine.jpg",
+        url: "https://images.unsplash.com/photo-1507924538820-ede94a04019d?auto=format&fit=crop&w=800&q=80",
+      },
+    ],
+  },
+  {
+    id: 105,
+    name: "Newborn essentials basket",
+    description: "Swaddles, muslin blankets, nail file, and gentle skincare in one grab-and-go kit.",
+    price: "120",
+    currency: "USD",
+    status: "available",
+    is_public: true,
+    is_reserved: false,
+    price_is_approx: false,
+    priority: 3,
+    tag: "care",
+    url: "https://example.com/essentials",
+    created_at: "2024-12-01T10:20:00Z",
+    user_id: demoOwnerId,
+    emoji: "🧴",
+    images: [
+      {
+        id: 206,
+        created_at: "2024-12-01T10:20:00Z",
+        wish_id: 105,
+        storage_object_name: "demo/essentials.jpg",
+        url: "https://images.unsplash.com/photo-1505751172876-fa1923c5c528?auto=format&fit=crop&w=800&q=80",
+      },
+    ],
+  },
+];
+
+const badges = [
+  "Baby registry ready",
+  "Free to share",
+  "English copy",
+  "Screenshot friendly",
+];
+
+export const BabyWishlistDemoPage: React.FC = () => {
+  return (
+    <div className="demo-page">
+      <header className="demo-hero">
+        <div>
+          <p className="eyebrow">Demo – Baby shower campaign</p>
+          <h1>Your modern baby wishlist</h1>
+          <p className="lead">
+            Show parents-to-be how effortless gifting can be. Share a curated, English-first
+            wishlist that feels warm, organized, and ready for screenshots.
+          </p>
+          <div className="badge-row">
+            {badges.map((label) => (
+              <Tag key={label} className="pill">{label}</Tag>
+            ))}
+          </div>
+        </div>
+        <div className="hero-note">
+          <p>Tip for ads</p>
+          <strong>Use this page to capture clean visuals without showing real data.</strong>
+        </div>
+      </header>
+
+      <section className="demo-grid" aria-label="Demo baby wishlist">
+        {demoWishes.map((wish) => (
+          <PublicWishCard key={wish.id} wish={wish} />
+        ))}
+      </section>
+    </div>
+  );
+};
+


### PR DESCRIPTION
## Summary
- add a login-free baby wishlist demo route for marketing screenshots
- build a curated set of baby registry cards with hero copy and responsive styling
- document the new demo entry point for easy discovery

## Testing
- CI=1 bun run --cwd packages/webapp vite build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930af6f8cd0832c9ead41e9ea15455d)