### PR TITLE
Invoke edge function on login

### DIFF
--- a/documentation/supabase-functions.md
+++ b/documentation/supabase-functions.md
@@ -68,3 +68,17 @@ Notes
 - This changes the primary auth email immediately and marks it confirmed. Use with care.
 - If you don't want to bypass confirmation, use `supabase.auth.updateUser({ email })` directly from the client instead.
 
+
+Supabase Edge Function: update-first-streams-on-artists
+
+Goal: Initialize artist streaming metadata when a user signs in.
+
+- Invoked automatically during anonymous login in `src/authProvider.ts` to keep artist stream data fresh.
+- Non-blocking: the login flow succeeds even if the function fails, but errors are logged to the console for visibility.
+- Call pattern from the client:
+
+```ts
+supabaseClient.functions.invoke("update-first-streams-on-artists").catch(console.error);
+```
+
+Ensure the edge function is deployed and accessible to authenticated users.

--- a/packages/webapp/src/authProvider.ts
+++ b/packages/webapp/src/authProvider.ts
@@ -30,6 +30,9 @@ const authProvider: AuthProvider = {
           id: data.user.id,
           slug: nanoid(),
         });
+
+      // Trigger artist stream initialization without blocking the login flow.
+      supabaseClient.functions.invoke("update-first-streams-on-artists").catch(console.error);
     }
 
     return {


### PR DESCRIPTION
## Summary
- trigger the `update-first-streams-on-artists` Supabase edge function during anonymous login to refresh artist stream data
- document the new edge-function usage in the global Supabase functions guide

## Testing
- bun run vite build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937e12a3fa0832c9a99f72240730ae2)